### PR TITLE
.end(... after sending error

### DIFF
--- a/lib/impress.js
+++ b/lib/impress.js
@@ -618,6 +618,7 @@
 	impress.error = function(req, res, code) {
 		res.writeHead(code);
 		res.write('<h2>Error: '+code+'</h2>');
+		res.end();
 		// send error page template here
 	}
 


### PR DESCRIPTION
When we call impress.error from impress.process, there is .end inside impress.process at line 602. But yes, inside impress.static at line 840 we have no .end(). I think it is better to put .end() inside impress.error and remove it from impress.process
