### PR TITLE
Fix multipart form-data fields.

### DIFF
--- a/lib/impress.js
+++ b/lib/impress.js
@@ -522,6 +522,7 @@
 											return;
 										} else {
 											req.impress.files = files;
+											req.impress.post = fields;
 											restoreSession(req, res);
 										}
 									});


### PR DESCRIPTION
Form data fields in multipart post request were parsed, but ignored and not added into `req.impress.post`.
