### PR TITLE
Add correct mime type for .svg

### DIFF
--- a/lib/impress.constants.js
+++ b/lib/impress.constants.js
@@ -26,7 +26,8 @@
 		jpeg:  "image/jpeg",
 		ogg:   "audio/ogg",
 		ico:   "image/x-icon",
-		manifest: "text/cache-manifest"
+		manifest: "text/cache-manifest",
+		svg:   "image/svg+xml"
 	};
 
 	impress.compressedExt = ["png", "jpg", "jpeg", "gif", "mp3", "ogg"];


### PR DESCRIPTION
Add correct mime type for .svg. Without it .svg files were transfered as text/html and in some browsers does not render them.
