### PR TITLE
Add support for PUT and DELETE HTTP methods

### DIFF
--- a/lib/impress.js
+++ b/lib/impress.js
@@ -502,7 +502,7 @@
 						}
 						if (host.process) {
 							// Read POST parameters
-							if (req.method === "POST") {
+							if (req.method === "POST" || req.method === "PUT" || req.method === "DELETE") {
 								var contentType = req.headers['content-type'];
 								if (contentType && contentType.startsWith('multipart')) {
 									var form = new impress.multiparty.Form();


### PR DESCRIPTION
Add missing  PUT and DELETE HTTP methods to impress. It is needed to support full rest api. PUT and DELETE requests are handled as a simple POST request (all params from formData go to `req.impress.post`).
