### PR TITLE
Version 0.1.42

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,13 @@
+0.1.42 / 2014-06-14
+==================
+
+  * Added passport.js as plugin with example using google oauth
+  * Before using passport.js you need:
+    - npm install passport
+    - npm install passport-google-oauth
+    - uncomment "impress.passport" in /config/plugins/js
+    - edit /applications/name/config/passport.js
+
 0.1.41 / 2014-06-11
 ==================
 

--- a/examples/copyContentToProjectFolder/applications/example/config/passport.js
+++ b/examples/copyContentToProjectFolder/applications/example/config/passport.js
@@ -1,19 +1,20 @@
 if (passport) {
 
-	var passport = require('passport');
+	var p = require('passport'),
+		pGoogle = require('passport-google-oauth');
 
 	// used to serialize the user for the session
-	passport.serializeUser(function(user, done) {
+	p.serializeUser(function(user, done) {
 		done(null, user);
 	});
 
 	// used to deserialize the user
-	passport.deserializeUser(function(user, done) {
+	p.deserializeUser(function(user, done) {
 		done(null, user);
 	});
 
 	module.exports = {
-		lib: passport,
+		lib: p,
 		strategies: {
 		    google: {
 		        param: {
@@ -21,7 +22,7 @@ if (passport) {
 		            clientSecret: 'Q4I-Z6YNgtouBAsg7NPM3gXd',
 		            callbackURL: '/api/auth/google/callback'
 		        },
-		        strategy: require('passport-google-oauth').OAuth2Strategy,
+		        strategy: pGoogle.OAuth2Strategy,
 		        authenticate: function(req, token, refreshToken, profile, done) {
 		            try {
 		                if (!req.user) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "Impressive Totalitarian-style Multipurpose Application Server for node.js. All decisions are made. Ready for applied development",
   "keywords": [


### PR DESCRIPTION
- Added passport.js as plugin with example using google oauth
- Before using passport.js you need:
- npm install passport
- npm install passport-google-oauth
- uncomment "impress.passport" in /config/plugins/js
- edit /applications/name/config/passport.js
