### PR TITLE
Bug fixed

### DIFF
--- a/lib/impress.firewall.js
+++ b/lib/impress.firewall.js
@@ -19,7 +19,9 @@ impress.firewall.srv = {};
 //
 impress.firewall.addApplication = function(application) {
 
-  if (!impress.config || !impress.config.scale.firewall.enabled) return;
+  if (!impress.config || 
+      !api.common.getByPath(impress.config, 'scale.firewall.enabled')) 
+    return;
 
   application.on('clientConnect', function(client) {
     var cfg = impress.config.scale.firewall.limits;


### PR DESCRIPTION
Logs were as these and worker repeatedly starts and terminates.

2016-07-26T10:47:24.235Z        Worker(20963/S1N2)      [impress]       TypeError: Cannot read property 'enabled' of undefined; Object.impress.firewall.addApplication (impress.firewall.js:22:56); Object.impress.application.mixin (impress.application.js:48:22); EventEmitter.impress.mixinPlugins (impress.js:111:30); EventEmitter.impress.loadApplication (impress.js:238:11); impress.js:220:24; impress.js:181:16; FSReqWrap.cb [as oncomplete] (fs.js:257:19)