### PR TITLE
Publish version 0.3.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "Impress Application Server for Node.js",
   "license": "MIT",
@@ -46,7 +46,7 @@
     "colors": "1.1.x",
     "mkdirp": "0.5.x",
     "ncp": "2.0.x",
-    "uglify-js": "2.7.x",
+    "uglify-js": "2.8.x",
     "multiparty": "4.1.x",
     "iconv-lite": "0.4.x",
     "zip-stream": "1.1.x",


### PR DESCRIPTION
May we also update following dependencies?
- MetaSync from `0.0.x` to `0.2.x`
- JSTP `0.5.x` to `0.6.x`
- GlobalStorege from `0.0.x` to `0.1.x`
@aqrln @belochub 