### PR TITLE
Avoid turning on impress autostart twice

### DIFF
--- a/install.js
+++ b/install.js
@@ -36,9 +36,7 @@ function execute(cmd, callback) {
 //
 function installCLI() {
   execute('npm install --unsafe-perm impress-cli -g', () => {
-    execute('impress path ' + destination, () => {
-      if (!isWin) execute('impress autostart on');
-    });
+    execute('impress path ' + destination);
   });
 }
 


### PR DESCRIPTION
Autostart is already being turned on during the installation of `impress-cli` package.