### PR TITLE
Don't eval frontend JavaScript files from /static

### DIFF
--- a/lib/impress.application.js
+++ b/lib/impress.application.js
@@ -532,6 +532,10 @@ impress.application.mixin = (application) => {
   };
 
   application.loadPlaceScripts = (placeName, callback) => {
+    if (placeName === 'static') {
+      callback();
+      return;
+    }
     const path = application.dir + '/' + placeName;
     api.fs.access(path, (err) => {
       if (err) {


### PR DESCRIPTION
Fix incorrect behavior of `application.loadPlaceScripts()` that used to load and evaluate all *.js files from directories listed in `impress.application.places`.  There is one directory we don't really want to load and execute on application startup: static frontend assets.

This was noticed as errors started to spill out of my terminal after I'd put assets that had contained a couple of plain old JavaScript files outside of main webpack-generated bundle (for specific reasons that aren't really relevant here) trying to access some browser-specific (even library-specific, actually) global variables, thus generating quite a bit of ReferenceErrors.

These errors don't hinder further application loading and startup, because `application.prepareScript()` only logs them and returns `null` values instead of exported objects (which is indistinguishable from modules actually exporting nulls which is kind of pointless but still
valid).  As far as I understand, this behavior cannot be blindly changed to treating these incidents as real errors unconditionally, because it's probably crucial for hot-reloading to work, especially in development mode with "broken from the point of view of the parser" being the normal state of the code, like, the whole time.  Separate error handling strategies for initial startup and hot reloading are probably necessary, but this is far outside the scope of this patch.

The reasons the bug doesn't reproduce itself loudly with any frontend
scripts (e.g., with the default application example):

 - Impress does not load files from subdirectories

 - most scripts actually start doing anything useful or interesting only in async callbacks, so we wouldn't probably see any errors even if those callbacks were executed

 - frontend bundles built with tools like webpack are extremely self-contained

The real problem is that the code is actually executed in the same sandbox that the rest of the application is. In other words, the code that is intended to be browser-only can literally write into the memory of the server: there's nothing stopping it from messing up with internals of namespaces like `api`.  I don't think this is much of a security concern at this point, but, without any doubt, it can lead to quite obscure bugs.