### PR TITLE
Avoid creation of redundant fields in application

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -27,7 +27,9 @@ impress.mixinPlugins = (application) => {
   for (i = 0; i < len; i++) {
     pluginName = CORE_PLUGINS[i];
     plugin = plugins[pluginName];
-    application[pluginName] = {};
-    if (plugin.mixinApplication) plugin.mixinApplication(application);
+    if (plugin.mixinApplication) {
+      application[pluginName] = {};
+      plugin.mixinApplication(application);
+    }
   }
 };


### PR DESCRIPTION
After the introduction of the plugin system, `application` object
included some unwanted fields named after the plugins with values
set to an empty object.