### PR TITLE
Update fs usages according to node v10 deprecations

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -615,7 +615,8 @@ const mixin = (application) => {
         application.model[sectionName] = exports;
       } else if (placeName === 'setup') {
         api.fs.writeFile(
-          path + '/' + sectionName + '.done', new Date().toISOString()
+          path + '/' + sectionName + '.done', new Date().toISOString(),
+          api.common.emptiness
         );
       }
       callback();


### PR DESCRIPTION
As per this https://github.com/nodejs/node/pull/12562 node PR callback
in async fs functions is no longer optional. This commit fixes
remaining usages in impress.

I've scanned impress, impress-cli and globalstorage for any of the usages of those fs functions. This should be the last one.