### PR TITLE
WIP: Use metaschema for config validation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -26,8 +26,22 @@ class Config {
 
   constructor(application) {
     this.application = application;
+    this.schemas = null;
     this.sandbox = null;
     this.sections = {};
+  }
+
+  loadSchemas(callback) {
+    const schemasDir = api.path.join(impress.moduleDir, 'schemas/config');
+    api.metaschema.fs.loadAndCreate(schemasDir, { api }, (err, schemas) => {
+      if (err) {
+        impress.log.error(err);
+        callback();
+        return;
+      }
+      this.schemas = schemas;
+      callback();
+    });
   }
 
   loadSandboxConfig(callback) {
@@ -91,6 +105,10 @@ class Config {
         return;
       }
       this.sections[sectionName] = exports;
+      if (this.schemas.categories.has(sectionName)) {
+        const error = this.schemas.validateCategory(sectionName, exports);
+        if (error && impress.isMaster) console.error(error.toString());
+      }
       callback();
     });
   }


### PR DESCRIPTION
I have a question about how to load schemas. Using synchronous `api.definition.require` it is loading schemas when `lib/core.js` is required
https://github.com/metarhia/impress/blob/2eea90822b682e7e1195376c3f8ecdcfed85ab1e/lib/core.js#L52-L60

But since the `api.metaschema.load` works asynchronously I think loading schemas on require is a bad idea
https://github.com/metarhia/impress/blob/1feab16b0ff6be07cc8dec46862801649c92f437/lib/core.js#L52-L76

I propose to define a separate function `impress.loadSchemas` and call it before `impress.loadConfig`
https://github.com/metarhia/impress/blob/2eea90822b682e7e1195376c3f8ecdcfed85ab1e/lib/core.js#L233-L267


Also there is some problems with validation. For example:
In `config.application.definition` there is a schema for `application` config, where field `slowTime` defined with a type `duration`
https://github.com/metarhia/impress/blob/2eea90822b682e7e1195376c3f8ecdcfed85ab1e/schemas/config.application.definition.js#L15-L20

And in `applications/example/config/application` `slowTime` is set as `'2s'`(string)
https://github.com/metarhia/impress/blob/2eea90822b682e7e1195376c3f8ecdcfed85ab1e/applications/example/config/application.js#L4

But in `metaschema` domain `Duration` has type `number`. What should I do then @tshemsedinov @nechaido @belochub?
