### PR TITLE
Fix invalid option name in jstp configuration

### DIFF
--- a/config/servers.js
+++ b/config/servers.js
@@ -33,7 +33,7 @@
     address:   '*',
     ports:     [3000, [1]], // Example: [81, [-1]]
     applications: ['example'],
-    heartbeat: '2s'
+    heartbeatInterval: '2s',
   },
 
   //secureRpc: {

--- a/schemas/config.impress.definition.js
+++ b/schemas/config.impress.definition.js
@@ -57,20 +57,20 @@
   servers: '{{server}}',
 
   server: {
-    protocol:     '(http,jstp)',
-    transport:    '(tcp,tls,ws,wss)',
-    address:      'string',
-    ports:        '[array]',
-    bundle:       'false:boolean',
-    nagle:        'false:boolean',
-    slowTime:     '4s:duration',
-    timeout:      '30s:duration',
-    keepAlive:    '5s:duration',
-    heartbeat:    '[duration]',
-    key:          '[string]',
-    cert:         '[string]',
-    applications: '[array]',
-    inspect:      '[number]'
+    protocol:          '(http,jstp)',
+    transport:         '(tcp,tls,ws,wss)',
+    address:           'string',
+    ports:             '[array]',
+    bundle:            'false:boolean',
+    nagle:             'false:boolean',
+    slowTime:          '4s:duration',
+    timeout:           '30s:duration',
+    keepAlive:         '5s:duration',
+    heartbeatInterval: '[duration]',
+    key:               '[string]',
+    cert:              '[string]',
+    applications:      '[array]',
+    inspect:           '[number]'
   }
 
 }


### PR DESCRIPTION
Starting with jstp@1.0.0 `heartbeat` option passed to the server has been changed to `heartbeatInterval`.

Refs: https://github.com/metarhia/impress/issues/892#issuecomment-438256037