### PR TITLE
Change JSTP messages log level to 'access'

### DIFF
--- a/lib/jstp.js
+++ b/lib/jstp.js
@@ -104,5 +104,5 @@ jstp.logger = (connection, event, ...args) => {
   }
   message += ' ' + connection.remoteAddress;
 
-  impress.log.info(message); // access
+  impress.log.access(message);
 };


### PR DESCRIPTION
JSTP messages are too verbose and low level to appear in the 'info'
log level. This commit changes them to be printed to 'access'.