### PR TITLE
Load application places sequentially

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -203,7 +203,7 @@ class Application extends api.events.EventEmitter {
   }
 
   loadPlaces(callback) {
-    api.metasync.each(PLACES, (placeName, next) => {
+    api.metasync.series(PLACES, (placeName, next) => {
       if (placeName === 'static') {
         next();
         return;


### PR DESCRIPTION
It appears that all application places are loaded simultaneously, which looks like a bug: intuitively `utils` should be loaded before `lib`, this PR aims to fix that.

This behavior was encountered by @lundibundi.