### PR TITLE
Fix .metadoc config file

### DIFF
--- a/.metadocrc
+++ b/.metadocrc
@@ -7,12 +7,12 @@
 
     "customLinks": {
         "Application": "https://github.com/metarhia/impress/blob/master/lib/application.js",
-        "Client": "https://github.com/metarhia/impress/blob/master/lib/client.js"
+        "Client": "https://github.com/metarhia/impress/blob/master/lib/client.js",
         "http.IncomingMessage": "https://nodejs.org/api/http.html#http_class_http_incomingmessage",
         "http.ServerResponse": "https://nodejs.org/api/http.html#http_class_http_serverresponse",
         "Buffer": "https://nodejs.org/api/buffer.html#buffer_class_buffer",
         "fs.Stats": "https://nodejs.org/api/fs.html#fs_class_fs_stats",
-        "bigint": "https://github.com/tc39/proposal-bigint",
+        "bigint": "https://github.com/tc39/proposal-bigint"
     },
 
     "outputDir": "doc/"


### PR DESCRIPTION
When https://github.com/metarhia/impress/pull/1087 and https://github.com/metarhia/impress/pull/1089 were landed types in `.metadoc` were not squashed correctly.

/cc @nechaido 