### PR TITLE
Make schemas/config.js optional

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -139,7 +139,10 @@ class Application extends api.events.EventEmitter {
             const path = api.path.join(relPath, fileName);
             this.preloadDirectory(path, depth - 1, next);
           } else if (fileExt === 'js') {
-            impress.createScript(this, filePath, next);
+            impress.createScript(this, filePath, (err, func) => {
+              if (err) this.log.error(impress.CANT_READ_FILE + filePath);
+              next(err, func);
+            });
           } else {
             next();
           }
@@ -196,6 +199,7 @@ class Application extends api.events.EventEmitter {
 
     impress.createScript(this, path, (err, test) => {
       if (err) {
+        this.log.error(impress.CANT_READ_FILE + path);
         callback(err);
         return;
       }
@@ -240,6 +244,7 @@ class Application extends api.events.EventEmitter {
   loadIntegrationTestFile(path, callback) {
     impress.createScript(this, path, (err, test) => {
       if (err) {
+        this.log.error(impress.CANT_READ_FILE + path);
         callback(err);
         return;
       }
@@ -322,6 +327,7 @@ class Application extends api.events.EventEmitter {
           }
           impress.createScript(this, filePath, (err, exports) => {
             if (err) {
+              this.log.error(impress.CANT_READ_FILE + filePath);
               next();
               return;
             }
@@ -481,8 +487,10 @@ class Application extends api.events.EventEmitter {
   //   callback <Function> file loaded
   loadPlaceFile(placeName, path, file, callback) {
     const sectionName = api.path.basename(file, '.js');
-    impress.createScript(this, api.path.join(path, file), (err, exports) => {
+    const fileName = api.path.join(path, file);
+    impress.createScript(this, fileName, (err, exports) => {
       if (err) {
+        this.log.error(impress.CANT_READ_FILE + fileName);
         callback();
         return;
       }

--- a/lib/application.js
+++ b/lib/application.js
@@ -348,8 +348,12 @@ class Application extends api.events.EventEmitter {
     const loaderPath = api.path.join(dir, 'config.js');
     impress.createScript(this, loaderPath, (err, getMsConfig) => {
       if (err) {
-        this.log.error(impress.CANT_READ_FILE + err.message);
-        callback(err);
+        if (err.code === 'ENOENT') {
+          callback(null);
+        } else {
+          this.log.error(impress.CANT_READ_FILE + loaderPath);
+          callback(err);
+        }
         return;
       }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -9,7 +9,10 @@ const extUpdate = {
   js: (application, filePath, relPath) => {
     application.cache.scripts.del(relPath);
     impress.createScript(application, filePath, (err, exports) => {
-      if (err) return;
+      if (err) {
+        application.log.error(impress.CANT_READ_FILE + filePath);
+        return;
+      }
       application.cache.scripts.add(relPath, exports);
       const sectionName = api.path.basename(filePath, '.js');
       let placeName = filePath.substring(application.dir.length + 1);

--- a/lib/client.js
+++ b/lib/client.js
@@ -594,6 +594,7 @@ class Client {
   runScript(handler, fileName, callback) {
     impress.createScript(this.application, fileName, (err, fn) => {
       if (err) {
+        this.application.log.error(impress.CANT_READ_FILE + fileName);
         callback(err);
         return;
       }

--- a/lib/config.js
+++ b/lib/config.js
@@ -87,6 +87,7 @@ class Config {
     }
     impress.createScript(this.application, configFile, (err, exports) => {
       if (err) {
+        this.application.log.error(impress.CANT_READ_FILE + configFile);
         callback();
         return;
       }

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -78,7 +78,6 @@ impress.createScript = (application, fileName, callback) => {
   }
   api.fs.readFile(fileName, (err, code) => {
     if (err) {
-      application.log.error(impress.CANT_READ_FILE + fileName);
       callback(err);
     } else {
       exports = prepareScript(application, fileName, code);


### PR DESCRIPTION
This will avoid impress crash when schemas/config.js doesn't exist.

e.g. when you create Impress application to only serve http or jstp requests you may not need the schemas at all.