### PR TITLE
Restrict serving application folder index

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -663,14 +663,12 @@ class Client {
   // Send static file and close connection
   //   onNotServed <Function> execute if file is not static
   static(onNotServed) {
-    let relPath = '/static';
-    if (this.path === '/') {
-      relPath = api.path.join(relPath, 'index.html');
-    } else {
+    const basePath = '/static';
+    let relPath = '/static/index.html';
+    if (this.path !== '/') {
       const url = api.querystring.unescape(this.url);
-      relPath = api.path.join(relPath, url);
-      // prevents from accessing the application scope
-      if (relPath === '/') relPath = '/static/index.html';
+      const safePath = api.path.join(basePath, url);
+      if (safePath.startsWith(basePath)) relPath = safePath;
     }
     if (!this.staticCache(relPath, onNotServed)) {
       this.serveStatic(relPath, onNotServed);
@@ -701,19 +699,13 @@ class Client {
 
     const serveFile = (err, stats) => {
       if (err) {
-        const isIndex = relPath.endsWith('/index.html');
-        if (this.path !== '/' && isIndex) {
-          this.index(api.path.dirname(filePath));
-        } else {
-          onNotServed();
-        }
+        onNotServed();
         application.cache.watch(api.path.dirname(relPath));
         return;
       }
       if (stats.isDirectory()) {
-        relPath = api.path.join(relPath, 'index.html');
         if (!this.staticCache(relPath, onNotServed)) {
-          this.serveStatic(relPath, onNotServed);
+          this.index(filePath);
         }
         return;
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -669,6 +669,8 @@ class Client {
     } else {
       const url = api.querystring.unescape(this.url);
       relPath = api.path.join(relPath, url);
+      // prevents from accessing the application scope
+      if (relPath === '/') relPath = '/static/index.html';
     }
     if (!this.staticCache(relPath, onNotServed)) {
       this.serveStatic(relPath, onNotServed);


### PR DESCRIPTION
We need to consider whether user can see the static folder index. By now, he can.