### PR TITLE
Update gs, eslint and metatests dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,9 +78,9 @@
       }
     },
     "acorn": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-      "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -88,6 +88,18 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
+    },
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -437,9 +449,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.15.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
-      "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -462,7 +474,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "inquirer": "^6.2.2",
-        "js-yaml": "^3.12.0",
+        "js-yaml": "^3.13.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
         "lodash": "^4.17.11",
@@ -480,18 +492,6 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -499,16 +499,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "eslint-scope": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
           }
         },
         "ms": {
@@ -580,6 +570,16 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-impress/-/eslint-plugin-impress-2.3.0.tgz",
       "integrity": "sha512-vP7WkusDkLfmMOBz8zQVpbP+/b8YkBveNEGsVt2GhSBG1ySk3zLF7nC3km5icusojEtjJR+al7veaTIZcHKrqA==",
       "dev": true
+    },
+    "eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
     },
     "eslint-utils": {
       "version": "1.3.1",
@@ -795,17 +795,17 @@
       "dev": true
     },
     "globalstorage": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/globalstorage/-/globalstorage-0.7.3.tgz",
-      "integrity": "sha512-b2LPlfJy57aYmqIEIFTX4SOn/Cp6sBBziIKsRUPxNd170e2XHJTsyGbf4sbfLMU8w5gkiCfQu4AJBzshnZwbHw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/globalstorage/-/globalstorage-0.9.0.tgz",
+      "integrity": "sha512-y77Gz/vVUC4lt0IVqKRgcjFYAMnX9iPccFQB2FLVik4ipFBv009Jnp0hLDv6rRB0ckAg6Ne8C2elxzaZoLqJZQ==",
       "requires": {
-        "@metarhia/common": "^1.2.1",
+        "@metarhia/common": "^1.3.1",
         "@metarhia/jstp": "^2.2.1",
         "mdsf": "^1.1.1",
         "metaschema": "^0.3.3",
         "metasync": "^0.3.31",
         "mkdirp": "^0.5.1",
-        "pg": "^7.8.2"
+        "pg": "^7.9.0"
       }
     },
     "graceful-fs": {
@@ -1152,9 +1152,9 @@
       }
     },
     "metatests": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/metatests/-/metatests-0.6.2.tgz",
-      "integrity": "sha512-S9Esy3Qm4YOLRpuJ7Ot/sDyasObta446dkPpg1vJVyOleXVrK4zmgYFWDE4QfDoqOcvm0eia+8ejUJaDI+sDnQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/metatests/-/metatests-0.6.3.tgz",
+      "integrity": "sha512-B0vbJqM6CDoWiseKNQfQ0325OtJ3ZXRlhNZZ/AXMPO2666bciYhzlHCchN3r6XGOHTBQ25zzVjks/h4fjtoMnQ==",
       "dev": true,
       "requires": {
         "@metarhia/common": "^1.4.2",
@@ -1366,9 +1366,9 @@
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
     "parent-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
@@ -1937,18 +1937,6 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "argon2": "^0.21.0",
     "concolor": "^0.1.11",
     "csv-stringify": "^5.3.0",
-    "globalstorage": "^0.7.3",
+    "globalstorage": "^0.9.0",
     "iconv-lite": "^0.4.24",
     "mdsf": "^1.1.1",
     "metalog": "^1.1.0",
@@ -73,10 +73,10 @@
   },
   "devDependencies": {
     "@metarhia/doc": "^0.2.1",
-    "eslint": "^5.15.3",
+    "eslint": "^5.16.0",
     "eslint-config-metarhia": "^7.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-impress": "^2.3.0",
-    "metatests": "^0.6.2"
+    "metatests": "^0.6.3"
   }
 }


### PR DESCRIPTION
This also fixes a few bugs in @metatests as per https://github.com/metarhia/metatests/pull/171.