### PR TITLE
Allow custom script timeout in application config

### DIFF
--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -27,9 +27,12 @@ const codeWrap = src => {
 // Returns: <Object> exported from script
 const prepareScript = (application, fileName, source) => {
   const key = application.relative(fileName);
+  const appConfig = application.config.sections.application;
+  const scriptTimeout =
+    appConfig && appConfig.scriptTimeout || SCRIPT_PREPARE_TIMEOUT;
   const options = {
     filename: fileName,
-    timeout: SCRIPT_PREPARE_TIMEOUT,
+    timeout: scriptTimeout,
     lineOffset: -2, // to compensate for USE_STRICT addition
   };
   let wrapper;


### PR DESCRIPTION
This allows to specify custom scriptTimeout in the application
config because currently hardcoded 500ms may not be enough to run
some scripts especially when running in constrained environment
(i.e. CI).