### PR TITLE
Fix parent test timeout in test mode

### DIFF
--- a/applications/example/config/application.test.js
+++ b/applications/example/config/application.test.js
@@ -1,0 +1,7 @@
+({
+  // Application test configuration
+
+  slowTime: Duration('1s'),
+
+  testTimeout: Duration('30s'),
+});

--- a/lib/core.js
+++ b/lib/core.js
@@ -43,6 +43,7 @@ impress.relative = path => path.substr(impress.dir.length);
 impress.DEFAULT_KEEP_ALIVE = api.common.duration('5s');
 impress.DEFAULT_TIMEOUT = api.common.duration('30s');
 impress.DEFAULT_SHUTDOWN = api.common.duration('5s');
+impress.APPLICATION_TEST_TIMEOUT = api.common.duration('5m');
 
 {
   const submodules = [
@@ -753,6 +754,8 @@ impress.startTests = () => {
   api.test.test('Impress applications test', test => {
     test.endAfterSubtests();
     Object.values(impress.applications).forEach(app => {
+      const appConfig = app.config.sections.application;
+      const timeout = appConfig.testTimeout || impress.APPLICATION_TEST_TIMEOUT;
       test.test(app.name, test => {
         test.endAfterSubtests();
         const testPattern = process.env.TEST_PATTERN;
@@ -761,9 +764,9 @@ impress.startTests = () => {
           .concat(app.tests.integration)
           .filter(({ path }) => !regex || regex.test(path))
           .forEach(testCase => test.test(testCase.path, testCase.test));
-      });
+      }, { timeout });
     });
-  });
+  }, { timeout: 0 });
   api.test.runner.instance.on('finish', hasErrors => {
     process.send({ name: 'impress:testsFinished', hasErrors });
   });


### PR DESCRIPTION
As of now metatests uses 30s as default test timeout therefore, because
impress in core.js when starting the subtests didn't change the timeout
value all tests were limited to being run no more that 30 seconds
in total and after this limit was reached would be forcefully finished.

This is obviously not enough for an extensive test suite.
This commit allows to specify a custom testTimeout in the application
config and disables timeout on the Impress parent test.