### PR TITLE
Allow to disable timeout for application tests in application.js config

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -755,7 +755,9 @@ impress.startTests = () => {
     test.endAfterSubtests();
     Object.values(impress.applications).forEach(app => {
       const appConfig = app.config.sections.application;
-      const timeout = appConfig.testTimeout || impress.APPLICATION_TEST_TIMEOUT;
+      const timeout = appConfig.testTimeout !== undefined ?
+        appConfig.testTimeout :
+        impress.APPLICATION_TEST_TIMEOUT;
       test.test(app.name, test => {
         test.endAfterSubtests();
         const testPattern = process.env.TEST_PATTERN;


### PR DESCRIPTION
This commit fixes the check of testTimeout to allow passing any value
as timeout. Therefore it is possible to put `testTimeout: 0` in
application.js config to disable the timeout for this application tests.

/cc @belochub 