### PR TITLE
Shorten paths in stack traces

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -14,8 +14,9 @@ const Console = require('./console.js');
   const configPath = path.join(application.path, 'config');
   const config = await new Config(configPath);
   const logPath = path.join(application.root, 'log');
+  const home = application.path;
   const logger = await metalog({
-    path: logPath, workerId: worker.threadId, ...config.sections.log
+    path: logPath, workerId: worker.threadId, ...config.sections.log, home
   });
   const console = new Console(logger);
   Object.assign(application, { config, logger, console });

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,11 +478,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1203,13 +1198,12 @@
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "metalog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/metalog/-/metalog-2.1.0.tgz",
-      "integrity": "sha512-v1eOyOfp90rNZMsF2wvVtVm6U0StoE9WTQ9stulH2BdlgAAfbZtl5w8lfJblIZ8a5nh3SJpGM3U9gmdqZRSADw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/metalog/-/metalog-2.2.0.tgz",
+      "integrity": "sha512-NO9wgXRX2Y5/vRO0brOwzIl6xKNERi/BAzYfDMCoGzjBpbU0fpNoYHFfRi8BCZGAioTyN+ngVyNIl+G2Tkq9ng==",
       "requires": {
         "@metarhia/common": "^2.1.0",
         "concolor": "^0.1.14",
-        "diff": "^4.0.2",
         "metastreams": "^0.1.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@metarhia/config": "^1.0.0",
     "accept-language": "^3.0.18",
     "concolor": "^0.1.13",
-    "metalog": "^2.1.0",
+    "metalog": "^2.2.0",
     "metaschema": "^0.4.0",
     "metasync": "^0.3.31",
     "multiparty": "^4.2.1",


### PR DESCRIPTION
- Update metalog to 2.2.0
- Pass `home` argument to metalog

Closes: https://github.com/metarhia/impress/issues/1228