### PR TITLE
Fix request consumption in server.js

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -18,14 +18,13 @@ const sample = arr => arr[Math.floor(Math.random() * arr.length)];
 
 const clients = new Map();
 
-const receiveBody = async req => new Promise(resolve => {
+const receiveBody = async req => {
   const buffers = [];
-  req.on('data', chunk => {
+  for await (const chunk of req) {
     buffers.push(chunk);
-  }).on('end', () => {
-    resolve(Buffer.concat(buffers).toString());
-  });
-});
+  }
+  return Buffer.concat(buffers).toString();
+};
 
 const closeClients = () => {
   for (const [connection, client] of clients.entries()) {
@@ -62,6 +61,8 @@ const listener = (req, res) => {
     }
     receiveBody(req).then(data => {
       client.message(data);
+    }, err => {
+      client.error(500, err);
     });
   } else {
     if (url === '/' && !req.connection.encrypted) {


### PR DESCRIPTION
Previously stream errors during `req` consumption would lead to a hanged
connection and resource/memory leak.
This also removes redundant double-promise from receiveBody.