### PR TITLE
Add config to global namespace

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -8,7 +8,6 @@ const security = require('./security.js');
 
 const SCRIPT_OPTIONS = { timeout: 5000 };
 const EMPTY_CONTEXT = Object.freeze({});
-const PLACE = 1;
 const MODULE = 2;
 
 class Application extends events.EventEmitter {
@@ -55,9 +54,11 @@ class Application extends events.EventEmitter {
     const application = { security, introspect };
     const lib = {};
     const domain = {};
+    const config = this.config.sections;
     for (const name of this.namespaces) application[name] = this[name];
     const sandbox = {
-      console: this.console, Buffer, application, node, npm, lib, domain,
+      Buffer, URL, URLSearchParams,
+      console: this.console, application, node, npm, lib, domain, config,
       setTimeout, setImmediate, setInterval,
       clearTimeout, clearImmediate, clearInterval,
     };
@@ -134,10 +135,6 @@ class Application extends events.EventEmitter {
         }
       } else {
         next = depth === last ? exp : {};
-        if (depth === PLACE) {
-          const config = this.config.sections[namespace];
-          if (config) next.config = config;
-        }
         level[namespace] = next;
         if (depth === MODULE && namespace === 'start') await this.execute(exp);
       }


### PR DESCRIPTION
Don't mixin configs to modules in `/lib` and `/domain`.
Now we can access configs by: `config.name.key`.

Closes: https://github.com/metarhia/impress/issues/1316