### PR TITLE
Remove node.js 13.x support, add 15.x to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
         node:
           - 12
           - 14
+          - 15
         os:
           - ubuntu-latest
           - windows-latest

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fmt": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/*.yml\""
   },
   "engines": {
-    "node": ">=12.9.0"
+    "node": "^12.9 || 14 || 15"
   },
   "dependencies": {
     "@metarhia/common": "^2.2.0",


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm run t`)
- [x] code is properly formatted (`npm run fmt`)
