### PR TITLE
Fix module loader (starts with `@metarhia/`)

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -11,7 +11,7 @@ const async = ['perf_hooks', 'async_hooks', 'timers', 'events'];
 const network = ['dns', 'net', 'tls', 'http', 'https', 'http2', 'dgram'];
 const internals = [...system, ...tools, ...streams, ...async, ...network];
 
-const ORG_LENGTH = '@metarhia'.length;
+const ORG_LENGTH = '@metarhia/'.length;
 const metalibs = ['@metarhia/common', '@metarhia/config'];
 const metacore = ['metavm', 'metacom', 'metaschema', 'metasql'];
 const metatools = ['metatests', 'metalog'];


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
