### PR TITLE
Use application.root as home for logger stack normalization

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -14,7 +14,7 @@ const { Auth } = require('./auth.js');
   const options = { mode: process.env.MODE };
   const config = await new Config(configPath, options);
   const logPath = path.join(application.root, 'log');
-  const home = application.path;
+  const home = application.root;
   const { threadId } = worker;
   const logger = await new Logger({
     path: logPath,


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
