### PR TITLE
Load application resources

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -225,10 +225,10 @@ class Application extends events.EventEmitter {
   }
 
   async loadResource(filePath) {
-    const key = filePath.substring(this.resourcePath.length);
+    const key = filePath.substring(this.resourcesPath.length);
     try {
       const data = await fsp.readFile(filePath);
-      this.resource.set(key, data);
+      this.resources.set(key, data);
     } catch (err) {
       if (err.code !== 'ENOENT') {
         this.console.error(err.stack);

--- a/lib/application.js
+++ b/lib/application.js
@@ -24,12 +24,14 @@ class Application extends events.EventEmitter {
     this.finalization = false;
     this.api = {};
     this.static = new Map();
+    this.resources = new Map();
     this.root = process.cwd();
     this.path = path.join(this.root, 'application');
     this.apiPath = path.join(this.path, 'api');
     this.libPath = path.join(this.path, 'lib');
     this.domainPath = path.join(this.path, 'domain');
     this.staticPath = path.join(this.path, 'static');
+    this.resourcesPath = path.join(this.path, 'resources');
     this.starts = [];
     this.Application = Application;
     this.Error = Error;
@@ -44,6 +46,7 @@ class Application extends events.EventEmitter {
     this.createSandbox();
     await Promise.allSettled([
       this.loadPlace('static', this.staticPath),
+      this.loadPlace('resources', this.resourcesPath),
       this.loadPlace('api', this.apiPath),
       (async () => {
         await this.loadPlace('lib', this.libPath);
@@ -72,12 +75,19 @@ class Application extends events.EventEmitter {
   }
 
   createSandbox() {
-    const { auth, config, console } = this;
+    const { auth, config, console, resources } = this;
     const { server: { host, port, protocol } = {} } = this;
     const introspect = async interfaces => this.introspect(interfaces);
     const worker = { id: 'W' + node.worker.threadId.toString() };
     const server = { host, port, protocol };
-    const application = { security, introspect, worker, server, auth };
+    const application = {
+      security,
+      introspect,
+      worker,
+      server,
+      auth,
+      resources,
+    };
     const api = {};
     const lib = {};
     const domain = {};
@@ -214,6 +224,18 @@ class Application extends events.EventEmitter {
     }
   }
 
+  async loadResource(filePath) {
+    const key = filePath.substring(this.resourcePath.length);
+    try {
+      const data = await fsp.readFile(filePath);
+      this.resource.set(key, data);
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        this.console.error(err.stack);
+      }
+    }
+  }
+
   async loadPlace(place, placePath) {
     const files = await fsp.readdir(placePath, { withFileTypes: true });
     for (const file of files) {
@@ -222,6 +244,7 @@ class Application extends events.EventEmitter {
       if (file.isDirectory()) await this.loadPlace(place, filePath);
       else if (place === 'api') await this.loadMethod(filePath);
       else if (place === 'static') await this.loadFile(filePath);
+      else if (place === 'resources') await this.loadResource(filePath);
       else await this.loadModule(filePath);
     }
     this.watch(place, placePath);
@@ -246,6 +269,7 @@ class Application extends events.EventEmitter {
       }
       if (place === 'api') this.loadMethod(filePath);
       else if (place === 'static') this.loadFile(filePath);
+      else if (place === 'resources') this.loadResource(filePath);
       else this.loadModule(filePath);
     });
   }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
