### PR TITLE
Improve dependency loader (allow optional)

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -13,8 +13,9 @@ const internals = [...system, ...tools, ...streams, ...async, ...network];
 
 const ORG_LENGTH = '@metarhia/'.length;
 const metalibs = ['@metarhia/common', '@metarhia/config'];
-const metacore = ['metavm', 'metacom', 'metaschema', 'metasql'];
-const metapkg = [...metalibs, ...metacore];
+const metacore = ['metavm', 'metacom', 'metalog'];
+const metaoptional = ['metaschema', 'metasql'];
+const metapkg = [...metalibs, ...metacore, ...metaoptional];
 
 const npmpkg = ['ws'];
 const pkg = require(process.cwd() + '/package.json');
@@ -23,7 +24,12 @@ if (pkg.dependencies) dependencies.push(...Object.keys(pkg.dependencies));
 
 for (const name of dependencies) {
   if (name === 'impress') continue;
-  const lib = require(name);
+  let lib = null;
+  try {
+    lib = require(name);
+  } catch {
+    continue;
+  }
   if (internals.includes(name)) {
     node[name] = lib;
     continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,11 +180,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
-    },
     "call-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
@@ -816,9 +811,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -926,7 +921,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1121,51 +1117,10 @@
         "metastreams": "^0.1.2"
       }
     },
-    "metaschema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/metaschema/-/metaschema-0.4.0.tgz",
-      "integrity": "sha512-uY0K7j6FiVriixcJyjV6ieSzEo4A0WrMp0U9YgMassPYMpuL/gQmkFnhUpID8wn+y/KU0Yr29scFZWWsVC9s+w==",
-      "requires": {
-        "@metarhia/common": "^1.2.1",
-        "metasync": "^0.3.31"
-      },
-      "dependencies": {
-        "@metarhia/common": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@metarhia/common/-/common-1.5.0.tgz",
-          "integrity": "sha512-hIiMPmIfDgyTl7Brn7qdAL2EqnsEoXqFUkfeMX5dQUGVjs+HO1NUR3J/KtUWeRuTNiiVQNeNtjB5j7dlZSsAqw=="
-        }
-      }
-    },
-    "metasql": {
-      "version": "0.3.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/metasql/-/metasql-0.3.0-alpha.2.tgz",
-      "integrity": "sha512-r6N5glppiWxenedbAPUB460xDamkGVPZUkbkxtUQGKbUVWLVF60mqtVzWqBtx+hH/rMD+BFrpMrAKw3PXj4k1A==",
-      "requires": {
-        "@metarhia/common": "^2.2.0",
-        "metavm": "0.1.0",
-        "pg": "^8.5.1"
-      },
-      "dependencies": {
-        "metavm": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/metavm/-/metavm-0.1.0.tgz",
-          "integrity": "sha512-Mm6US1huNdH402mgBEnuFYnL6SzM4vufwnT4ivSGwjm40vyQMYEL8Fy8DBK3uI9qLW2eWgU0Nav2N+wgj/ojaw=="
-        }
-      }
-    },
     "metastreams": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/metastreams/-/metastreams-0.1.2.tgz",
       "integrity": "sha512-6wnujNYQyCuAQHimJWBDP59feTwlY2D1P8kf2AONC8k6oQxve3EXCTiL4E87oSWoyoIHMWcPXtOT4BZdVyAbDQ=="
-    },
-    "metasync": {
-      "version": "0.3.32",
-      "resolved": "https://registry.npmjs.org/metasync/-/metasync-0.3.32.tgz",
-      "integrity": "sha512-E+NeMCXhp7oUtTipm2KM4Eq+Fp5ZK5AiezIt0FZX5Vu4mxcaexcmQZ6Z48j/w2SzVoLqX94vcwGXPqeV9r8APA==",
-      "requires": {
-        "@metarhia/common": "^2.1.0"
-      }
     },
     "metatests": {
       "version": "0.7.2",
@@ -1323,11 +1278,6 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
-    "packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1379,60 +1329,6 @@
         "pify": "^2.0.0"
       }
     },
-    "pg": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
-      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
-      "requires": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.4.0",
-        "pg-pool": "^3.2.2",
-        "pg-protocol": "^1.4.0",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x"
-      }
-    },
-    "pg-connection-string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
-      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
-    },
-    "pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
-    },
-    "pg-pool": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
-      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
-    },
-    "pg-protocol": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
-      "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
-    },
-    "pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "requires": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      }
-    },
-    "pgpass": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
-      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
-      "requires": {
-        "split2": "^3.1.1"
-      }
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1446,29 +1342,6 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
-      }
-    },
-    "postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
-    },
-    "postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
-    },
-    "postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
-    },
-    "postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "requires": {
-        "xtend": "^4.0.0"
       }
     },
     "prelude-ls": {
@@ -1525,16 +1398,6 @@
         "read-pkg": "^2.0.0"
       }
     },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -1577,11 +1440,6 @@
       "requires": {
         "glob": "^7.1.3"
       }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "semver": {
       "version": "7.3.4",
@@ -1656,14 +1514,6 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
-    "split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "requires": {
-        "readable-stream": "^3.0.0"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1716,14 +1566,6 @@
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -1881,11 +1723,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
     "v8-compile-cache": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
@@ -1993,11 +1830,6 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
       "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
     "@metarhia/config": "^2.0.0",
     "metacom": "1.0.0-alpha.0",
     "metalog": "^3.0.0",
-    "metaschema": "^0.4.0",
-    "metasql": "^0.3.0-alpha.2",
     "metavm": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Wrap require to try/catch block to load optional dependencies
- Move metasql and metaschema to optional dependencies
- Return metalog to required dependencies

Refs: https://github.com/metarhia/impress/issues/1417

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
