### PR TITLE
Calculate and cache signatures for introspection

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -23,6 +23,7 @@ class Application extends events.EventEmitter {
     this.initialization = true;
     this.finalization = false;
     this.api = {};
+    this.signatures = {};
     this.static = new Map();
     this.resources = new Map();
     this.root = process.cwd();
@@ -155,8 +156,27 @@ class Application extends events.EventEmitter {
     let methods = iface[ver];
     if (!methods) iface[ver] = methods = {};
     methods[name] = script;
-    internalInterface[name] = script(EMPTY_CONTEXT);
+    const exp = script(EMPTY_CONTEXT);
+    internalInterface[name] = exp;
+    this.cacheSignature(iname + '.' + version, name, exp);
     if (version > iface.default) iface.default = version;
+  }
+
+  cacheSignature(interfaceName, methodName, exp) {
+    let interfaceMethods = this.signatures[interfaceName];
+    if (!interfaceMethods) {
+      interfaceMethods = {};
+      this.signatures[interfaceName] = interfaceMethods;
+    }
+    interfaceMethods[methodName] = this.getSignature(exp);
+  }
+
+  getSignature(exp) {
+    const fn = typeof exp === 'object' ? exp.method : exp;
+    const src = fn.toString();
+    const signature = common.between(src, '({', '})');
+    if (signature === '') return [];
+    return signature.split(',').map((s) => s.trim());
   }
 
   addModule(namespaces, exports, iface) {
@@ -281,22 +301,7 @@ class Application extends events.EventEmitter {
       const iface = this.api[iname];
       if (!iface) continue;
       const version = ver === '*' ? iface.default : parseInt(ver);
-      const methods = iface[version.toString()];
-      const methodNames = Object.keys(methods);
-      const interfaceMethods = {};
-      intro[iname] = interfaceMethods;
-      for (const methodName of methodNames) {
-        const exp = methods[methodName](EMPTY_CONTEXT);
-        const fn = typeof exp === 'object' ? exp.method : exp;
-        const src = fn.toString();
-        const signature = common.between(src, '({', '})');
-        if (signature === '') {
-          interfaceMethods[methodName] = [];
-          continue;
-        }
-        const args = signature.split(',').map((s) => s.trim());
-        interfaceMethods[methodName] = args;
-      }
+      intro[iname] = this.signatures[iname + '.' + version];
     }
     return intro;
   }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
