### PR TITLE
Support scalar values

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -49,23 +49,25 @@ const check = (name, def, value) => {
 
 class Schema {
   constructor(name, raw) {
+    const scalar = typeof raw === 'string' || Reflect.has(raw, 'type');
+    const defs = scalar ? { value: raw } : raw;
     this.name = name;
     this.scope = 'system';
-    this.kind = 'entity';
+    this.kind = scalar ? 'scalar' : 'entity';
     this.fields = {};
     this.indexes = {};
-    this.validate = raw.validate || null;
-    this.format = raw.format || null;
-    this.parse = raw.parse || null;
-    this.serialize = raw.serialize || null;
-    this.preprocess(raw);
+    this.validate = defs.validate || null;
+    this.format = defs.format || null;
+    this.parse = defs.parse || null;
+    this.serialize = defs.serialize || null;
+    this.preprocess(defs);
   }
 
-  preprocess(raw) {
-    const keys = Object.keys(raw);
+  preprocess(defs) {
+    const keys = Object.keys(defs);
     let first = true;
     for (const key of keys) {
-      const value = raw[key];
+      const value = defs[key];
       if (first && isUpperCamel(key)) {
         const { scope, kind } = parseDirective(value);
         this.scope = scope;
@@ -96,7 +98,8 @@ class Schema {
     return new Schema('', raw);
   }
 
-  check(target) {
+  check(value) {
+    const target = typeof value === 'object' ? value : { value };
     const keys = Object.keys(target);
     const fields = Object.keys(this.fields);
     const names = new Set([...keys, ...fields]);
@@ -114,7 +117,5 @@ class Schema {
     return { valid: errors.length === 0, errors };
   }
 }
-
-Schema.check = check;
 
 module.exports = { Schema };

--- a/test/schema.js
+++ b/test/schema.js
@@ -98,9 +98,22 @@ metatests.test('lib/schema negative', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema static check', (test) => {
-  const definition = { type: 'string' };
-  const err = Schema.check('result', definition, 'value');
-  test.strictSame(err.length, 0);
+metatests.test('lib/schema check scalar', (test) => {
+  {
+    const definition = { type: 'string' };
+    const schema = Schema.from(definition);
+    test.strictSame(schema.check('value').valid, true);
+    test.strictSame(schema.check(1917).valid, false);
+    test.strictSame(schema.check(true).valid, false);
+    test.strictSame(schema.check({}).valid, false);
+  }
+  {
+    const definition = 'string';
+    const schema = Schema.from(definition);
+    test.strictSame(schema.check('value').valid, true);
+    test.strictSame(schema.check(1917).valid, false);
+    test.strictSame(schema.check(true).valid, false);
+    test.strictSame(schema.check({}).valid, false);
+  }
   test.end();
 });


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
