### PR TITLE
Use path.sep and replace it to '/' in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Fixed path separators to support windows
+
 ## [2.0.1][] - 2021-01-09
 
 - Use metautil instead of metarhia/common for core utilities

--- a/lib/application.js
+++ b/lib/application.js
@@ -8,6 +8,7 @@ const security = require('./security.js');
 
 const EMPTY_CONTEXT = Object.freeze({});
 const MODULE = 2;
+const win = process.platform === 'win32';
 
 class Error extends global.Error {
   constructor(message, code) {
@@ -120,8 +121,8 @@ class Application extends events.EventEmitter {
 
   async loadMethod(fileName) {
     const rel = fileName.substring(this.apiPath.length + 1);
-    if (!rel.includes('/')) return;
-    const [interfaceName, methodFile] = rel.split('/');
+    if (!rel.includes(path.sep)) return;
+    const [interfaceName, methodFile] = rel.split(path.sep);
     if (!methodFile.endsWith('.js')) return;
     const name = path.basename(methodFile, '.js');
     const [iname, ver] = interfaceName.split('.');
@@ -215,7 +216,8 @@ class Application extends events.EventEmitter {
   }
 
   async loadFile(filePath) {
-    const key = filePath.substring(this.staticPath.length);
+    let key = filePath.substring(this.staticPath.length);
+    if (win) key = metautil.replace(key, path.sep, '/');
     try {
       const data = await fsp.readFile(filePath);
       this.static.set(key, data);
@@ -227,7 +229,8 @@ class Application extends events.EventEmitter {
   }
 
   async loadResource(filePath) {
-    const key = filePath.substring(this.resourcesPath.length);
+    let key = filePath.substring(this.resourcesPath.length);
+    if (win) key = metautil.replace(key, path.sep, '/');
     try {
       const data = await fsp.readFile(filePath);
       this.resources.set(key, data);


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1441

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] added to changelog