### PR TITLE
Added relative path in logged stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Fixed exception handling in module loader
+- Added relative path in logged stack traces
 
 ## [2.0.2][] - 2021-01-26
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -194,7 +194,7 @@ class Application extends events.EventEmitter {
     const name = path.basename(rel, '.js');
     const namespaces = rel.split(path.sep);
     namespaces[namespaces.length - 1] = name;
-    const options = { context: this.sandbox };
+    const options = { context: this.sandbox, filename: fileName };
     try {
       const script = await metavm.readScript(fileName, options);
       let exports = script.exports;


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
