### PR TITLE
Fix application initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed exception handling in module loader
 - Added relative path in logged stack traces
+- Fixed application initializtion flag
 
 ## [2.0.2][] - 2021-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed exception handling in module loader
 - Added relative path in logged stack traces
 - Fixed application initializtion flag
+- Catch exceptions in application initialization
 
 ## [2.0.2][] - 2021-01-26
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -58,7 +58,7 @@ class Application extends events.EventEmitter {
     ]);
     await Promise.allSettled(this.starts.map((fn) => this.execute(fn)));
     this.starts = [];
-    this.initialization = true;
+    this.initialization = false;
   }
 
   async shutdown() {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -26,8 +26,14 @@ const { Auth } = require('./auth.js');
   const auth = new Auth({ ...config.sessions });
   Object.assign(application, { config, logger, console, auth });
 
-  const logError = (err) => {
+  const logError = async (err) => {
     console.error(err ? err.stack : 'No exception stack available');
+    if (application.finalization) return;
+    if (application.initialization) {
+      console.info(`Can not start Application in worker ${threadId}`);
+      await application.shutdown();
+      process.exit(0);
+    }
   };
 
   process.on('uncaughtException', logError);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
