### PR TITLE
Load TLS certificates only if we need HTTPS or WSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Load TLS certificates only if we need HTTPS or WSS
+
 ## [2.0.3][] - 2021-01-29
 
 - Fixed exception handling in module loader

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -40,13 +40,16 @@ const { Auth } = require('./auth.js');
   process.on('warning', logError);
   process.on('unhandledRejection', logError);
 
-  const certPath = path.join(application.path, 'cert');
-  try {
-    const key = await fsp.readFile(path.join(certPath, 'key.pem'));
-    const cert = await fsp.readFile(path.join(certPath, 'cert.pem'));
-    application.cert = { key, cert };
-  } catch {
-    if (threadId === 1) console.error('Can not load TLS certificates');
+  if (config.server.protocol === 'https') {
+    const certPath = path.join(application.path, 'cert');
+    try {
+      const key = await fsp.readFile(path.join(certPath, 'key.pem'));
+      const cert = await fsp.readFile(path.join(certPath, 'cert.pem'));
+      application.cert = { key, cert };
+    } catch {
+      if (threadId === 1) console.error('Can not load TLS certificates');
+      process.exit(0);
+    }
   }
 
   const { balancer, ports = [] } = config.server;


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1444

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
