### PR TITLE
Update dependencies: metarhia/config to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Update metarhia/config to 2.1.0
+
 ## [2.0.6][] - 2021-02-09
 
 - Revert to lock-file version 1

--- a/impress.js
+++ b/impress.js
@@ -12,8 +12,9 @@ const CFG_PATH = path.join(PATH, 'application/config');
 const CTRL_C = 3;
 
 (async () => {
-  const options = { mode: process.env.MODE };
-  const config = await new Config(CFG_PATH, options, ['server']);
+  const options = { mode: process.env.MODE, names: ['server'] };
+  const config = await new Config(CFG_PATH, options);
+  console.log(config);
   if (!config.server) {
     console.log('Can not read configuration: application/config/server.js');
     process.exit(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,9 +68,9 @@
       "dev": true
     },
     "@metarhia/config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@metarhia/config/-/config-2.0.0.tgz",
-      "integrity": "sha512-B3crYuGxU4R62JAjYG38cpO6Zps+OCG/9whoW4LH72NbPt6x5/PAissK4ol3QDdYhtyVmyvA4sk1TD3SGJsYOQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@metarhia/config/-/config-2.1.0.tgz",
+      "integrity": "sha512-puRxc+UkoHR8IqAZqlWNA5CMXSH09rZDP3tQs39BgVz+lf4TAHhB2ZqluDCfpL3ym2W2ay/eQQGkoz2cX+43Eg==",
       "requires": {
         "metavm": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "node": "^12.9 || 14 || 15"
   },
   "dependencies": {
-    "@metarhia/config": "^2.0.0",
-    "metacom": "1.3.1",
+    "@metarhia/config": "^2.1.0",
+    "metacom": "^1.3.1",
     "metalog": "^3.1.0",
     "metautil": "^3.2.0",
     "metavm": "^1.0.0"


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
