### PR TITLE
Optimize module loader and signature cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Use schema validation in `application.invoke`
+- Optimize module loader and signature cache
 
 ## [2.0.7][] - 2021-02-13
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -18,6 +18,13 @@ class Error extends global.Error {
 
 const SANDBOX = { ...metavm.COMMON_CONTEXT, Error, node, npm, metarhia };
 
+const getSignature = (method) => {
+  const src = method.toString();
+  const signature = metautil.between(src, '({', '})');
+  if (signature === '') return [];
+  return signature.split(',').map((s) => s.trim());
+};
+
 class Application extends events.EventEmitter {
   constructor() {
     super();
@@ -115,7 +122,7 @@ class Application extends events.EventEmitter {
     const method = methods[methodName];
     if (!method) return null;
     const exp = method(context);
-    return typeof exp === 'object' ? exp : { access: 'logged', method: exp };
+    return typeof exp === 'object' ? exp : { method: exp };
   }
 
   async loadMethod(fileName) {
@@ -139,26 +146,18 @@ class Application extends events.EventEmitter {
     if (!methods) iface[ver] = methods = {};
     methods[name] = script;
     const exp = script(EMPTY_CONTEXT);
-    internalInterface[name] = exp;
-    this.cacheSignature(iname + '.' + version, name, exp);
+    const proc = typeof exp === 'object' ? exp : { method: exp };
+    internalInterface[name] = proc;
+    this.cacheSignature(iname + '.' + version, name, proc.method);
     if (version > iface.default) iface.default = version;
   }
 
-  cacheSignature(interfaceName, methodName, exp) {
+  cacheSignature(interfaceName, methodName, method) {
     let interfaceMethods = this.signatures[interfaceName];
     if (!interfaceMethods) {
-      interfaceMethods = {};
-      this.signatures[interfaceName] = interfaceMethods;
+      this.signatures[interfaceName] = interfaceMethods = {};
     }
-    interfaceMethods[methodName] = this.getSignature(exp);
-  }
-
-  getSignature(exp) {
-    const fn = typeof exp === 'object' ? exp.method : exp;
-    const src = fn.toString();
-    const signature = metautil.between(src, '({', '})');
-    if (signature === '') return [];
-    return signature.split(',').map((s) => s.trim());
+    interfaceMethods[methodName] = getSignature(method);
   }
 
   addModule(namespaces, exports, iface) {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
