### PR TITLE
Reworked application api in-memory structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use schema validation in `application.invoke`
 - Optimize module loader and signature cache
+- Reworked application api in-memory structure
 
 ## [2.0.7][] - 2021-02-13
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -113,16 +113,26 @@ class Application extends events.EventEmitter {
     }
   }
 
-  getMethod(iname, ver, methodName, context) {
+  getMethod(iname, ver, methodName) {
     const iface = this.api[iname];
     if (!iface) return null;
-    const version = ver === '*' ? iface.default : parseInt(ver);
+    const version = ver === '*' ? iface.default : parseInt(ver, 10);
     const methods = iface[version.toString()];
     if (!methods) return null;
-    const method = methods[methodName];
-    if (!method) return null;
-    const exp = method(context);
-    return typeof exp === 'object' ? exp : { method: exp };
+    const proc = methods[methodName];
+    console.dir(proc, { depth: null });
+    return proc;
+  }
+
+  preprocessProc(script) {
+    const exp = script(EMPTY_CONTEXT);
+    if (typeof exp === 'object') {
+      let { parameters, returns } = exp;
+      if (parameters) parameters = Schema.from(parameters);
+      if (returns) returns = Schema.from(returns);
+      return { ...exp, parameters, returns, script };
+    }
+    return { method: exp, script };
   }
 
   async loadMethod(fileName) {
@@ -135,6 +145,7 @@ class Application extends events.EventEmitter {
     const version = parseInt(ver, 10);
     const script = await this.createScript(fileName);
     if (!script) return;
+    const proc = this.preprocessProc(script);
     let iface = this.api[iname];
     const { api } = this.sandbox;
     let internalInterface = api[iname];
@@ -142,14 +153,13 @@ class Application extends events.EventEmitter {
       this.api[iname] = iface = { default: version };
       api[iname] = internalInterface = {};
     }
+    if (version > iface.default) iface.default = version;
     let methods = iface[ver];
     if (!methods) iface[ver] = methods = {};
-    methods[name] = script;
-    const exp = script(EMPTY_CONTEXT);
-    const proc = typeof exp === 'object' ? exp : { method: exp };
-    internalInterface[name] = proc;
-    this.cacheSignature(iname + '.' + version, name, proc.method);
-    if (version > iface.default) iface.default = version;
+    const { method } = proc;
+    methods[name] = proc;
+    internalInterface[name] = method;
+    this.cacheSignature(iname + '.' + version, name, method);
   }
 
   cacheSignature(interfaceName, methodName, method) {
@@ -210,16 +220,18 @@ class Application extends events.EventEmitter {
     });
   }
 
-  async invoke(proc, args = {}) {
+  async invoke(context, proc, args = {}) {
+    const exp = proc.script(context);
+    const method = typeof exp === 'object' ? exp.method : exp;
     if (proc.parameters) {
-      const schema = Schema.from(proc.parameters);
-      if (!schema.check(args).valid) return new Error('Invalid parameter type');
+      const { valid } = proc.parameters.check(args);
+      if (!valid) return new Error('Invalid parameter type');
     }
-    const result = await proc.method(args);
+    const result = await method(args);
     if (result instanceof this.Error) return result;
     if (proc.returns) {
-      const schema = Schema.from(proc.returns);
-      if (!schema.check(result).valid) return new Error('Invalid result type');
+      const { valid } = proc.returns.check(result);
+      if (!valid) return new Error('Invalid result type');
     }
     return result;
   }


### PR DESCRIPTION
- Removed `context` argument in `application.getMethod`
- Added `context` argument in `application.invoke`
- Implemented `application.preprocessProc` to precomple schemas

Closes: https://github.com/metarhia/impress/issues/1474
Closes: https://github.com/metarhia/impress/issues/1475
Closes: https://github.com/metarhia/impress/issues/1476

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
