### PR TITLE
Fix bug in Procedure locking with semaphore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Fix bug in Procedure locking with semaphore
+
 ## [2.0.9][] - 2021-02-19
 
 - Extract Procedure class from Application

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -28,7 +28,7 @@ class Procedure {
       try {
         await this.semaphore.enter();
       } catch (err) {
-        this.application.semaphore.leave();
+        this.application.server.semaphore.leave();
         throw err;
       }
     }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
