### PR TITLE
Output everything before log init in metalog style

### DIFF
--- a/impress.js
+++ b/impress.js
@@ -7,33 +7,39 @@ const path = require('path');
 
 const { Config } = require('@metarhia/config');
 const metavm = require('metavm');
+const metautil = require('metautil');
 const { loadSchema } = require('metaschema');
+const { Logger } = require('metalog');
 
 const CONFIG_SECTIONS = ['log', 'scale', 'server', 'sessions'];
 const PATH = process.cwd();
 const CFG_PATH = path.join(PATH, 'application/config');
+const LOG_PATH = path.join(PATH, 'log');
 const CTRL_C = 3;
 
-const exit = (message) => {
-  console.log(message);
-  process.exit(1);
-};
-
-const validateConfig = async (config) => {
-  const schemaPath = path.join(__dirname, 'schemas/config');
-  let valid = true;
-  for (const section of CONFIG_SECTIONS) {
-    const schema = await loadSchema(path.join(schemaPath, section + '.js'));
-    const checkResult = schema.check(config[section]);
-    if (!checkResult.valid) {
-      for (const err of checkResult.errors) console.log(err);
-      valid = false;
-    }
-  }
-  if (!valid) exit('Can not start server');
-};
-
 (async () => {
+  const logOpt = { path: LOG_PATH, workerId: 0, toFile: [] };
+  const { console } = await new Logger(logOpt);
+
+  const exit = (message) => {
+    console.error(metautil.replace(message, PATH, ''));
+    process.exit(1);
+  };
+
+  const validateConfig = async (config) => {
+    const schemaPath = path.join(__dirname, 'schemas/config');
+    let valid = true;
+    for (const section of CONFIG_SECTIONS) {
+      const schema = await loadSchema(path.join(schemaPath, section + '.js'));
+      const checkResult = schema.check(config[section]);
+      if (!checkResult.valid) {
+        for (const err of checkResult.errors) console.error(err);
+        valid = false;
+      }
+    }
+    if (!valid) exit('Can not start server');
+  };
+
   const context = metavm.createContext({ process });
   const options = { mode: process.env.MODE, context };
   const config = await new Config(CFG_PATH, options).catch((err) => {
@@ -66,7 +72,7 @@ const validateConfig = async (config) => {
     worker.on('online', () => {
       if (++starting === count) {
         startTimer = setTimeout(() => {
-          if (active !== count) console.log('Server initialization timed out');
+          if (active !== count) console.warn('Server initialization timed out');
         }, config.server.timeouts.start);
       }
     });


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1516

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
