### PR TITLE
Remove logger message about port bind (moved to metacom)

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -78,8 +78,6 @@ const validateConfig = async (config) => {
   const servingThreads = ports.length + (balancer ? 1 : 0);
   if (threadId <= servingThreads) {
     application.server = new Server(config.server, application);
-    const { port } = application.server;
-    console.info(`Listen port ${port} in worker ${threadId}`);
   }
 
   await application.init();


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
