### PR TITLE
Rename live reload timeout: `reload` to `watch`

### DIFF
--- a/schemas/config/server.js
+++ b/schemas/config/server.js
@@ -9,7 +9,7 @@
     start: 'number',
     stop: 'number',
     request: 'number',
-    reload: 'number',
+    watch: 'number',
   },
   queue: {
     concurrency: 'number',

--- a/test/config/server.js
+++ b/test/config/server.js
@@ -7,9 +7,9 @@
   timeouts: {
     bind: 2000,
     start: 30000,
-    stop: 30000,
+    stop: 5000,
     request: 5000,
-    reload: 1000,
+    watch: 1000,
   },
   queue: {
     concurrency: 1000,


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
