### PR TITLE
Use metawatch 1.0.0 instead of internal watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Use metawatch 1.0.0 instead of internal watcher
+
 ## [2.1.0][] - 2021-03-15
 
 - Improve server start and stop

--- a/lib/application.js
+++ b/lib/application.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { node, npm, metarhia } = require('./dependencies.js');
-const { path, events, fs, fsp } = node;
-const { metautil, metavm } = metarhia;
+const { path, events, fsp } = node;
+const { metautil, metavm, metawatch } = metarhia;
 const { Procedure } = require('./procedure.js');
 
 const MODULE = 2;
@@ -48,9 +48,11 @@ class Application extends events.EventEmitter {
     this.logger = null;
     this.console = null;
     this.auth = null;
+    this.watcher = null;
   }
 
   async init() {
+    this.startWatch();
     this.createSandbox();
     await Promise.allSettled([
       this.loadPlace('static', this.staticPath),
@@ -244,13 +246,16 @@ class Application extends events.EventEmitter {
       else if (place === 'resources') await this.loadResource(filePath);
       else await this.loadModule(filePath);
     }
-    this.watch(place, placePath);
+    this.watcher.watch(placePath);
   }
 
-  watch(place, placePath) {
-    fs.watch(placePath, async (event, fileName) => {
-      if (fileName.startsWith('.')) return;
-      const filePath = path.join(placePath, fileName);
+  startWatch() {
+    const timeout = this.config.server.timeouts.watch;
+    this.watcher = new metawatch.DirectoryWatcher({ timeout });
+    const onChange = async (filePath) => {
+      const relPath = filePath.substring(this.path.length + 1);
+      const sepIndex = relPath.indexOf(path.sep);
+      const place = relPath.substr(0, sepIndex);
       try {
         const stat = await node.fsp.stat(filePath);
         if (stat.isDirectory()) {
@@ -261,13 +266,20 @@ class Application extends events.EventEmitter {
         return;
       }
       if (node.worker.threadId === 1) {
-        const relPath = filePath.substring(this.path.length);
-        this.console.debug('Reload: ' + relPath);
+        this.console.debug('Reload: /' + relPath);
       }
       if (place === 'api') this.loadMethod(filePath);
       else if (place === 'static') this.loadFile(filePath);
       else if (place === 'resources') this.loadResource(filePath);
       else this.loadModule(filePath);
+    };
+    this.watcher.on('change', onChange);
+    this.watcher.on('rename', onChange);
+    this.watcher.on('delete', async (filePath) => {
+      const relPath = filePath.substring(this.path.length);
+      if (node.worker.threadId === 1) {
+        this.console.debug('Deleted: /' + relPath);
+      }
     });
   }
 

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -13,7 +13,7 @@ const internals = [...system, ...tools, ...streams, ...async, ...network];
 
 const ORG_LENGTH = '@metarhia/'.length;
 const metalibs = ['@metarhia/config'];
-const metacore = ['metautil', 'metavm', 'metacom', 'metalog'];
+const metacore = ['metautil', 'metavm', 'metacom', 'metalog', 'metawatch'];
 const metaoptional = ['metaschema', 'metasql'];
 const metapkg = [...metalibs, ...metacore, ...metaoptional];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1150,6 +1150,11 @@
       "resolved": "https://registry.npmjs.org/metavm/-/metavm-1.0.0.tgz",
       "integrity": "sha512-Rfj28pYS1W6FxF1uFAB0m+PfmpZEPGjPLjYGKUjDYXY23cJSg1Gxq3iVFO2/RYg9nTGV8mF8uLreDJxn2snPZQ=="
     },
+    "metawatch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/metawatch/-/metawatch-1.0.0.tgz",
+      "integrity": "sha512-tSSQwgdkPbu5EffIt6BG6PjZj3ngZZhunZK29SNPJb3tI6moZ7jJoIw7E31RHmNkNeMoNI8EEnJKW4Dh0n9e6Q=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "metalog": "^3.1.1",
     "metaschema": "^1.0.2",
     "metautil": "^3.5.1",
-    "metavm": "^1.0.0"
+    "metavm": "^1.0.0",
+    "metawatch": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.35",


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1214

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
