### PR TITLE
Improve error handling in Cache and subclasses

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { node, npm, metarhia } = require('./dependencies.js');
-const { path, events } = node;
+const { path, events, fs } = node;
 const { metavm, metawatch } = metarhia;
 
 const { Interfaces } = require('./interfaces.js');
@@ -113,23 +113,21 @@ class Application extends events.EventEmitter {
     const timeout = this.config.server.timeouts.watch;
     this.watcher = new metawatch.DirectoryWatcher({ timeout });
 
-    this.watcher.on('change', async (filePath) => {
+    this.watcher.on('change', (filePath) => {
       const relPath = filePath.substring(this.path.length + 1);
       const sepIndex = relPath.indexOf(path.sep);
       const place = relPath.substring(0, sepIndex);
-      try {
-        const stat = await node.fsp.stat(filePath);
+      fs.stat(filePath, (err, stat) => {
+        if (err) return;
         if (stat.isDirectory()) {
-          this.loadPlace(place, filePath);
+          this[place].load(filePath);
           return;
         }
-      } catch {
-        return;
-      }
-      if (node.worker.threadId === 1) {
-        this.console.debug('Reload: /' + relPath);
-      }
-      this[place].change(filePath);
+        if (node.worker.threadId === 1) {
+          this.console.debug('Reload: /' + relPath);
+        }
+        this[place].change(filePath);
+      });
     });
 
     this.watcher.on('delete', async (filePath) => {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -58,12 +58,18 @@ class Modules extends Cache {
   async change(filePath) {
     if (!filePath.endsWith('.js')) return;
     const options = { context: this.application.sandbox, filename: filePath };
-    const script = await metavm.readScript(filePath, options);
-    let exports = script.exports;
-    if (typeof exports === 'function') exports = { method: exports };
-    const iface = metautil.makePrivate(exports);
-    const relPath = filePath.substring(this.path.length + 1);
-    this.set(relPath, exports, iface);
+    try {
+      const script = await metavm.readScript(filePath, options);
+      let exports = script.exports;
+      if (typeof exports === 'function') exports = { method: exports };
+      const iface = metautil.makePrivate(exports);
+      const relPath = filePath.substring(this.path.length + 1);
+      this.set(relPath, exports, iface);
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        this.application.console.error(err.stack);
+      }
+    }
   }
 }
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -31,7 +31,9 @@ class Resources extends Cache {
       const data = await fsp.readFile(filePath);
       this.files.set(key, data);
     } catch (err) {
-      if (err.code !== 'ENOENT') throw err;
+      if (err.code !== 'ENOENT') {
+        this.application.console.error(err.stack);
+      }
     }
   }
 }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
