### PR TITLE
Fix modules loader after Application decomposition

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,10 +1,9 @@
 'use strict';
 
-const { fsp, path, events } = require('./dependencies.js').node;
+const { fsp, path } = require('./dependencies.js').node;
 
-class Cache extends events.EventEmitter {
+class Cache {
   constructor(place, application) {
-    super();
     this.path = application.absolute(place);
     this.application = application;
   }

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -38,9 +38,8 @@ class Modules extends Cache {
         }
         next = iface.method || iface;
         exports.parent = level;
-      } else {
-        next = {};
       }
+      if (next === undefined) next = {};
       level[name] = next;
       if (depth === MODULE && name === 'start') {
         this.emit('start', iface.method);

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -6,8 +6,6 @@ const { metavm, metautil } = metarhia;
 
 const { Cache } = require('./cache.js');
 
-const MODULE = 2;
-
 const parsePath = (relPath) => {
   const name = path.basename(relPath, '.js');
   const names = relPath.split(path.sep);
@@ -28,8 +26,10 @@ class Modules extends Cache {
     for (let depth = 0; depth <= last; depth++) {
       const name = names[depth];
       let next = level[name];
-      if (next && depth === MODULE && name === 'stop') {
-        if (exports === null && level.stop) this.emit('stop', level.stop);
+      if (next && depth === 1 && name === 'stop') {
+        if (exports === null && level.stop) {
+          this.application.exacute(level.stop);
+        }
       }
       if (depth === last) {
         if (exports === null) {
@@ -41,8 +41,8 @@ class Modules extends Cache {
       }
       if (next === undefined) next = {};
       level[name] = next;
-      if (depth === MODULE && name === 'start') {
-        this.emit('start', iface.method);
+      if (depth === 1 && name === 'start') {
+        this.application.starts.push(iface.method);
       }
       level = next;
     }

--- a/test/modules.js
+++ b/test/modules.js
@@ -8,6 +8,8 @@ const root = process.cwd();
 
 const application = {
   path: path.join(root, 'test'),
+  console,
+  starts: [],
   absolute(relative) {
     return path.join(this.path, relative);
   },


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
