### PR TITLE
Fix sandbox namespaces

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -88,8 +88,8 @@ class Application extends events.EventEmitter {
     application.introspect = async (interfaces) => this.introspect(interfaces);
     const sandbox = { ...SANDBOX, console, application, config };
     sandbox.api = {};
-    sandbox.lib = {};
-    sandbox.domain = {};
+    sandbox.lib = this.lib.tree;
+    sandbox.domain = this.domain.tree;
     this.sandbox = metavm.createContext(sandbox);
   }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
