### PR TITLE
Update metawatch to fix directory reload bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Stop module only if module folder removed, not just `stop.js` file
+- Update metawatch to fix bug: load created directory after delete
 
 ## [2.1.1][] - 2021-03-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1178,9 +1178,9 @@
       "integrity": "sha512-Rfj28pYS1W6FxF1uFAB0m+PfmpZEPGjPLjYGKUjDYXY23cJSg1Gxq3iVFO2/RYg9nTGV8mF8uLreDJxn2snPZQ=="
     },
     "metawatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/metawatch/-/metawatch-1.0.2.tgz",
-      "integrity": "sha512-gLkn+Qto+3uq+bRMgjpe23tu1woTH9XMD1RfNIURZIt8MYS9IJZKBxh6X0wOEk7CRG2cZKkwNTEsBs6NzbBZjQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/metawatch/-/metawatch-1.0.3.tgz",
+      "integrity": "sha512-PJtbKcV7VMaLcKc6drqqDA3ox6e1037WMHIKY763PMzCQXXxg8Me0O88sfRPK+ACowzyZFw99rBLVAQ0OBFJoA=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "metaschema": "^1.0.2",
     "metautil": "^3.5.1",
     "metavm": "^1.0.0",
-    "metawatch": "^1.0.2"
+    "metawatch": "^1.0.3"
   },
   "devDependencies": {
     "@types/node": "^14.14.37",


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
