### PR TITLE
Eslint: change arrow-parens to always

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "ecmaVersion": 2020
   },
   "rules": {
-    "arrow-parens": "off",
+    "arrow-parens": ["error", "always"],
     "comma-dangle": "off",
     "handle-callback-err": "off",
     "consistent-return": "off"


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
