### PR TITLE
Сorrectly handle the absence of `method` in api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Use metaconfiguration (renamed @metarhia/config)
+- Сorrectly handle the absence of method in api
 
 ## [2.2.0][] - 2021-04-15
 

--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -82,8 +82,9 @@ class Interfaces extends Cache {
     if (version > iface.default) iface.default = version;
     let methods = iface[ver];
     if (!methods) iface[ver] = methods = {};
-    const { method } = proc;
     methods[name] = proc;
+    const { method } = proc;
+    if (!method) return;
     internalInterface[name] = method;
     this.cacheSignature(iname + '.' + version, name, method);
   }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
