### PR TITLE
Typo in code

### DIFF
--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -28,7 +28,7 @@ class Procedure {
     this.access = exp.access || '';
     this.validate = exp.validate || null;
     this.timeout = exp.timeout || 0;
-    this.sirializer = exp.sirialize || null;
+    this.serializer = exp.serialize || null;
     this.protocols = exp.protocols || null;
     this.deprecated = exp.deprecated || false;
     this.assert = exp.assert || null;


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
