### PR TITLE
Remove duplicated config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Remove duplicated config validation
+
 ## [2.4.1][] - 2021-07-01
 
 - Implement basic API plugin system

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -7,33 +7,12 @@ const application = require('./application.js');
 const { Config } = metarhia.metaconfiguration;
 const { Logger } = metarhia.metalog;
 const { Server } = metarhia.metacom;
-const { loadSchema } = metarhia.metaschema;
-
-const CONFIG_SECTIONS = ['log', 'scale', 'server', 'sessions'];
-
-const validateConfig = async (config) => {
-  const schemaPath = path.join(__dirname, '../schemas/config');
-  let valid = true;
-  for (const section of CONFIG_SECTIONS) {
-    const schema = await loadSchema(path.join(schemaPath, section + '.js'));
-    const checkResult = schema.check(config[section]);
-    if (!checkResult.valid) {
-      for (const err of checkResult.errors) console.log(err);
-      valid = false;
-    }
-  }
-  if (!valid) {
-    console.error('Can not start server');
-    process.exit(1);
-  }
-};
 
 (async () => {
   const configPath = path.join(application.path, 'config');
   const context = metarhia.metavm.createContext({ process });
   const options = { mode: process.env.MODE, context };
   const config = await new Config(configPath, options);
-  await validateConfig(config);
   const logPath = path.join(application.root, 'log');
   const home = application.root;
   const { threadId } = worker;


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
