### PR TITLE
Refactor impress internal dependencies loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+- Refactor impress internal dependencies loading
+- Remove access to `worker_threads` from application
+
 ## [2.6.0][] - 2021-09-08
 
 - Allow third party plugins (not only metarhia npm modules)

--- a/impress.js
+++ b/impress.js
@@ -4,7 +4,6 @@ process.title = 'impress';
 
 const { Worker } = require('worker_threads');
 const path = require('path');
-
 const { Config } = require('metaconfiguration');
 const metavm = require('metavm');
 const metautil = require('metautil');

--- a/lib/application.js
+++ b/lib/application.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const { node, npm, metarhia } = require('./dependencies.js');
-const { path, events, fs } = node;
-const { metavm, metawatch } = metarhia;
+const path = require('path');
+const events = require('events');
+const fs = require('fs');
+const metavm = require('metavm');
+const metawatch = require('metawatch');
 const { Interfaces } = require('./interfaces.js');
 const { Modules } = require('./modules.js');
 const { Resources } = require('./resources.js');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { metautil } = require('./dependencies.js').metarhia;
+const metautil = require('metautil');
 
 const accounts = new Map();
 const sessions = new Map();

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { fsp, path } = require('./dependencies.js').node;
+const path = require('path');
+const fsp = require('fs').promises;
 
 class Cache {
   constructor(place, application) {

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -4,7 +4,7 @@ const node = { process };
 const npm = {};
 const metarhia = {};
 
-const system = ['util', 'child_process', 'worker_threads', 'os', 'v8', 'vm'];
+const system = ['util', 'child_process', 'os', 'v8', 'vm'];
 const tools = ['path', 'url', 'string_decoder', 'querystring', 'assert'];
 const streams = ['stream', 'fs', 'crypto', 'zlib', 'readline'];
 const async = ['perf_hooks', 'async_hooks', 'timers', 'events'];
@@ -12,10 +12,7 @@ const network = ['dns', 'net', 'tls', 'http', 'https', 'http2', 'dgram'];
 const internals = [...system, ...tools, ...streams, ...async, ...network];
 
 const ORG_LENGTH = '@metarhia/'.length;
-const metalibs = ['metaconfiguration'];
-const metacore = ['metautil', 'metavm', 'metacom', 'metalog', 'metawatch'];
-const metaoptional = ['metaschema', 'metasql'];
-const metapkg = [...metalibs, ...metacore, ...metaoptional];
+const metapkg = ['metautil', 'metacom', 'metaschema', 'metasql'];
 
 const npmpkg = ['ws'];
 const pkg = require(process.cwd() + '/package.json');
@@ -49,7 +46,6 @@ node.childProcess = node['child_process'];
 node.StringDecoder = node['string_decoder'];
 node.perfHooks = node['perf_hooks'];
 node.asyncHooks = node['async_hooks'];
-node.worker = node['worker_threads'];
 node.fsp = node.fs.promises;
 
 Object.freeze(node);

--- a/lib/files.js
+++ b/lib/files.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const { node, metarhia } = require('./dependencies.js');
-const { fs, fsp, path } = node;
-const { metautil } = metarhia;
+const path = require('path');
+const fs = require('fs');
+const fsp = fs.promises;
+const metautil = require('metautil');
 const application = require('./application.js');
 
 const COMPRESSED = [

--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -1,8 +1,10 @@
 'use strict';
 
-const { node, metarhia, npm } = require('./dependencies.js');
-const { fsp, path } = node;
-const { metavm, metautil } = metarhia;
+const path = require('path');
+const fsp = require('fs').promises;
+const metavm = require('metavm');
+const metautil = require('metautil');
+const { metarhia, npm } = require('./dependencies.js');
 const { Procedure } = require('./procedure.js');
 const { Cache } = require('./cache.js');
 

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const { node, metarhia } = require('./dependencies.js');
-const { path } = node;
-const { metavm } = metarhia;
+const path = require('path');
+const metavm = require('metavm');
 const { Cache } = require('./cache.js');
 
 const parsePath = (relPath) => {

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { metautil, metaschema } = require('./dependencies.js').metarhia;
+const metautil = require('metautil');
 const { Semaphore, createAbortController } = metautil;
-const { Schema } = metaschema;
+const { Schema } = require('metaschema');
 
 const EMPTY_CONTEXT = Object.freeze({});
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { node, metarhia } = require('./dependencies.js');
-const { fsp, path } = node;
-const { metautil } = metarhia;
+const path = require('path');
+const fsp = require('fs').promises;
+const metautil = require('metautil');
 const { Cache } = require('./cache.js');
 
 const win = process.platform === 'win32';

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const { node, metarhia } = require('./dependencies.js');
-const { fsp, path, worker } = node;
-const { metautil } = metarhia;
+const path = require('path');
+const fsp = require('fs').promises;
+const worker = require('worker_threads');
+const metautil = require('metautil');
 
 const findHandler = (sandbox, name) => {
   const [key, rest] = metautil.split(name, '.');

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const { node, metarhia } = require('./dependencies.js');
-const { path } = node;
-const { Model, loadSchema } = metarhia.metaschema;
+const path = require('path');
+const { Model, loadSchema } = require('metaschema');
 const { Cache } = require('./cache.js');
 
 class Schemas extends Cache {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,15 +1,18 @@
 'use strict';
 
-const { node, metarhia, notLoaded } = require('./dependencies.js');
-const { worker, fsp, path } = node;
+const path = require('path');
+const fsp = require('fs').promises;
+const worker = require('worker_threads');
+const { Config } = require('metaconfiguration');
+const { Logger } = require('metalog');
+const { Server } = require('metacom');
+const metavm = require('metavm');
+const { notLoaded } = require('./dependencies.js');
 const application = require('./application.js');
-const { Config } = metarhia.metaconfiguration;
-const { Logger } = metarhia.metalog;
-const { Server } = metarhia.metacom;
 
 (async () => {
   const configPath = path.join(application.path, 'config');
-  const context = metarhia.metavm.createContext({ process });
+  const context = metavm.createContext({ process });
   const options = { mode: process.env.MODE, context };
   const config = await new Config(configPath, options);
   const logPath = path.join(application.root, 'log');

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -6,6 +6,6 @@ const dependencies = require('../lib/dependencies.js');
 metatests.test('lib/dependencies', async (test) => {
   test.strictSame(typeof dependencies.node.os, 'object');
   test.strictSame(typeof dependencies.npm.ws, 'function');
-  test.strictSame(typeof dependencies.metarhia.metavm, 'object');
+  test.strictSame(typeof dependencies.metarhia.metaschema, 'object');
   test.end();
 });


### PR DESCRIPTION
Including remove access to `worker_threads` from application
Refs: https://github.com/metarhia/impress/issues/1626

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
