### PR TITLE
Dependency loader fixed, `metasql` is optional now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Dependency loader fixed, `metasql` is optional now
+
 ## [2.6.3][] - 2021-09-22
 
 - Implement exclusive thread capture to execute `application.invoke`

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -11,13 +11,13 @@ const async = ['perf_hooks', 'async_hooks', 'timers', 'events'];
 const network = ['dns', 'net', 'tls', 'http', 'https', 'http2', 'dgram'];
 const internals = [...system, ...tools, ...streams, ...async, ...network];
 
-const ORG_LENGTH = '@metarhia/'.length;
-const metapkg = ['metautil', 'metacom', 'metaschema', 'metasql'];
+const optional = ['metasql'];
+const metapkg = ['metautil', 'metacom', 'metaschema', ...optional];
 
 const npmpkg = ['ws'];
 const pkg = require(process.cwd() + '/package.json');
-const dependencies = [...internals, ...npmpkg, ...metapkg];
-if (pkg.dependencies) dependencies.push(...Object.keys(pkg.dependencies));
+if (pkg.dependencies) npmpkg.push(...Object.keys(pkg.dependencies));
+const dependencies = [...internals, ...npmpkg, ...metapkg, ...optional];
 
 const notLoaded = new Set();
 
@@ -27,7 +27,9 @@ for (const name of dependencies) {
   try {
     lib = require(name);
   } catch {
-    notLoaded.add(name);
+    if (npmpkg.includes(name) || !optional.includes(name)) {
+      notLoaded.add(name);
+    }
     continue;
   }
   if (internals.includes(name)) {
@@ -35,8 +37,7 @@ for (const name of dependencies) {
     continue;
   }
   if (metapkg.includes(name)) {
-    const key = name.startsWith('@') ? name.substring(ORG_LENGTH) : name;
-    metarhia[key] = lib;
+    metarhia[name] = lib;
     continue;
   }
   npm[name] = lib;


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1660

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
