### PR TITLE
fix: import packages

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -17,7 +17,7 @@ const metapkg = ['metautil', 'metacom', 'metaschema', ...optional];
 const npmpkg = ['ws'];
 const pkg = require(process.cwd() + '/package.json');
 if (pkg.dependencies) npmpkg.push(...Object.keys(pkg.dependencies));
-const dependencies = [...internals, ...npmpkg, ...metapkg, ...optional];
+const dependencies = [...internals, ...npmpkg, ...metapkg];
 
 const notLoaded = new Set();
 


### PR DESCRIPTION
Removed duplicate when importing optional packages.

<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
