### PR TITLE
Fix: pass `release` flag back to thread manager

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -212,7 +212,7 @@ class Application extends events.EventEmitter {
 const application = new Application();
 
 if (parentPort) {
-  parentPort.on('message', async ({ type, name, data, port }) => {
+  parentPort.on('message', async ({ type, name, exclusive, data, port }) => {
     if (type !== 'invoke' || name !== 'request') return;
     const { method, args } = data;
     const handler = metautil.namespaceByPath(application.sandbox, method);
@@ -227,7 +227,7 @@ if (parentPort) {
       port.postMessage({ error: err });
       application.console.error(err.stack);
     } finally {
-      parentPort.postMessage({ type: 'invoke', name: 'done' });
+      parentPort.postMessage({ type: 'invoke', name: 'done', exclusive });
     }
   });
 }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
