### PR TITLE
Make `scheduler` field optional in `config/server.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Move `node.process` object to a sandbox context
+- Make `scheduler` field optional in `config/server.js`
 
 ## [2.6.5][] - 2021-09-30
 

--- a/schemas/config/server.js
+++ b/schemas/config/server.js
@@ -17,9 +17,9 @@
     timeout: 'number',
   },
   scheduler: {
-    concurrency: 'number',
-    size: 'number',
-    timeout: 'number',
+    concurrency: '?number',
+    size: '?number',
+    timeout: '?number',
   },
   workers: {
     pool: 'number',


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1674

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
