### PR TITLE
Allow async procedure validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add cors to server config
 - Update metatests dependency
+- Allow `async` procedure `validate` function
 
 ## [2.6.6][] - 2021-10-12
 

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -64,7 +64,12 @@ class Procedure {
       if (!valid) return new Error('Invalid parameters type: ' + problems);
     }
     if (validate) {
-      validate(args);
+      try {
+        await validate(args);
+      } catch (err) {
+        if (err instanceof this.application.Error) return err;
+        throw err;
+      }
     }
     let result;
     if (timeout) {

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -64,12 +64,7 @@ class Procedure {
       if (!valid) return new Error('Invalid parameters type: ' + problems);
     }
     if (validate) {
-      try {
-        await validate(args);
-      } catch (err) {
-        if (err instanceof this.application.Error) return err;
-        throw err;
-      }
+      await validate(args);
     }
     let result;
     if (timeout) {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->
We already have `parameters` for sync\input validation, this PR allow to perform more involved validation in `validate` if needed.
This also doesn't remove the ability to write `sync` functions since `await` will work just fine.

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
