### PR TITLE
Fix test example: asunc start function

### DIFF
--- a/test/cache/example/start.js
+++ b/test/cache/example/start.js
@@ -1,12 +1,8 @@
-({
-  privateField: 100,
-
-  async method() {
-    if (application.worker.id === 'W1') {
-      console.debug('Start example plugin');
-      this.parent.cache.set({ key: 'keyName', val: this.privateField });
-      const res = lib.example.cache.get({ key: 'keyName' });
-      console.debug({ res, cache: this.parent.cache.values });
-    }
-  },
-});
+async () => {
+  if (application.worker.id === 'W1') {
+    console.debug('Start example plugin');
+    this.parent.cache.set({ key: 'keyName', val: 'value' });
+    const res = lib.example.cache.get({ key: 'keyName' });
+    console.debug({ res, cache: this.parent.cache.values });
+  }
+};


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
