### PR TITLE
Use config for logger initialization in thread 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Do not call stop() on directories during shutdown
+- Use config for logger initialization in thread 0
 
 ## [2.6.9][] - 2022-04-01
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
