### PR TITLE
Fix clear introspection signature cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Fix clear introspection signature cache
+
 ## [3.0.0-alpha.1][] - 2022-06-25
 
 - Worker-based multitenancy implementation

--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -61,6 +61,8 @@ class Interfaces extends Cache {
     if (methods) delete methods[name];
     const internalInterface = this.application.sandbox.api[iname];
     if (internalInterface) delete internalInterface[name];
+    const cache = this.signatures[interfaceName];
+    if (cache) delete cache[name];
   }
 
   async change(filePath) {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
