### PR TITLE
Exit on initializatopn timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Exit on initializatopn timeout
+
 ## [3.0.0-alpha.4][] - 2022-07-30
 
 - Fix scheduler: task id, unknown app, etc.

--- a/impress.js
+++ b/impress.js
@@ -42,7 +42,7 @@ const exit = async (message) => {
 };
 
 const logError = (type) => (err) => {
-  const msg = err.stack || err.message || 'no stack trace';
+  const msg = err?.stack || err?.message || 'exit';
   impress.console.error(`${type}: ${msg}`);
   if (impress.finalization) return;
   if (impress.initialization) exit('Can not start Application server');
@@ -205,9 +205,10 @@ const stop = async () => {
   process.on('SIGINT', stop);
   process.on('SIGTERM', stop);
 
-  impress.startTimer = setTimeout(() => {
-    impress.console.warn(`Initialization timeout`);
-  }, config.server.timeouts.start);
+  impress.startTimer = setTimeout(
+    logError('Initialization timeout'),
+    config.server.timeouts.start,
+  );
 
   await loadApplications();
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
