### PR TITLE
Move `serveStatic` from metacom

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const wt = require('worker_threads');
 const { MessageChannel, parentPort, threadId } = wt;
 const workerData = wt.workerData || { path: process.cwd() };
+const metautil = require('metautil');
 const metavm = require('metavm');
 const metawatch = require('metawatch');
 const { Interfaces } = require('./interfaces.js');
@@ -237,6 +238,27 @@ class Application extends events.EventEmitter {
       });
       parentPort.postMessage(msg, [port]);
     });
+  }
+
+  serveStatic(channel) {
+    const { req, res } = channel;
+    if (res.writableEnded) return;
+    const { url } = req;
+    const [urlPath, params] = metautil.split(url, '?');
+    const folder = urlPath.endsWith('/');
+    const filePath = urlPath + (folder ? 'index.html' : '');
+    const fileExt = metautil.fileExt(filePath);
+    const data = this.getStaticFile(filePath);
+    if (data) {
+      channel.write(data, 200, fileExt);
+      return;
+    }
+    if (!folder && this.getStaticFile(urlPath + '/index.html')) {
+      const query = params ? '?' + params : '';
+      channel.redirect(urlPath + '/' + query);
+      return;
+    }
+    channel.error(404);
   }
 }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
