### PR TITLE
Make node:test optional dependency

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -6,21 +6,15 @@ const node = {};
 const npm = {};
 const metarhia = {};
 
-const system = ['util', 'buffer', 'child_process', 'os', 'v8', 'vm'];
-const tools = [
-  'path',
-  'url',
-  'string_decoder',
-  'querystring',
-  'assert',
-  'test',
-];
+const sys = ['util', 'buffer', 'child_process', 'os', 'v8', 'vm'];
+const tools = ['path', 'url', 'string_decoder', 'querystring'];
+const test = ['assert', 'test'];
 const streams = ['stream', 'fs', 'crypto', 'zlib', 'readline'];
 const async = ['perf_hooks', 'async_hooks', 'timers', 'events'];
-const network = ['dns', 'net', 'tls', 'http', 'https', 'http2', 'dgram'];
-const internals = [...system, ...tools, ...streams, ...async, ...network];
+const net = ['dns', 'net', 'tls', 'http', 'https', 'http2', 'dgram'];
+const internals = [...sys, ...tools, ...streams, ...async, ...net, ...test];
 
-const optional = ['metasql'];
+const optional = ['metasql', 'test'];
 const metapkg = ['metautil', 'metacom', 'metaschema', ...optional];
 
 const npmpkg = ['ws'];


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
