### PR TITLE
Change Server constructor signature

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -63,7 +63,7 @@ process.on('unhandledRejection', logError('unhandledRejection'));
   const { kind, port } = workerData;
   if (kind === 'server' || kind === 'balancer') {
     const options = { ...config.server, port, kind };
-    application.server = new Server(options, application);
+    application.server = new Server(application, options);
   }
 
   const stop = async () => {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
