### PR TITLE
Support new node.js features

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -7,7 +7,7 @@ const npm = {};
 const metarhia = {};
 
 const sys = ['util', 'buffer', 'child_process', 'os', 'v8', 'vm'];
-const tools = ['path', 'url', 'string_decoder', 'querystring'];
+const tools = ['path', 'string_decoder', 'querystring'];
 const test = ['assert', 'test'];
 const streams = ['stream', 'fs', 'crypto', 'zlib', 'readline'];
 const async = ['perf_hooks', 'async_hooks', 'timers', 'events'];

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const metautil = require('metautil');
-const { Semaphore, createAbortController } = metautil;
+const { Semaphore } = metautil;
 const { Schema } = require('metaschema');
 
 const EMPTY_CONTEXT = Object.freeze({});
@@ -66,7 +66,7 @@ class Procedure {
     if (validate) await validate(args);
     let result;
     if (timeout) {
-      const ac = createAbortController();
+      const ac = new AbortController();
       result = await Promise.race([
         metautil.timeout(timeout, ac.signal),
         method(args),


### PR DESCRIPTION
Due to drop of node.js 14 support we can use features listed here: https://github.com/HowProgrammingWorks/Drop-Nodejs14

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
