### PR TITLE
Add Content-Length header for servces.js

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -8,7 +8,8 @@ const { Schema } = require('metaschema');
 const request = (url, { method, body }) =>
   new Promise((resolve, reject) => {
     const proto = url.startsWith('https') ? https : http;
-    const headers = { 'Content-Type': 'application/json', 'Content-Length': body ? Buffer.byteLength(body) : 0 };
+    const len = body ? Buffer.byteLength(body) : 0;
+    const headers = { 'Content-Type': 'application/json', 'Content-Length': len };
     const req = proto.request(url, { method, headers }, (res) => {
       const code = res.statusCode;
       if (code !== 200) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -8,8 +8,9 @@ const { Schema } = require('metaschema');
 const request = (url, { method, body }) =>
   new Promise((resolve, reject) => {
     const proto = url.startsWith('https') ? https : http;
+    const mimeType = 'application/json';
     const len = body ? Buffer.byteLength(body) : 0;
-    const headers = { 'Content-Type': 'application/json', 'Content-Length': len };
+    const headers = { 'Content-Type': mimeType, 'Content-Length': len };
     const req = proto.request(url, { method, headers }, (res) => {
       const code = res.statusCode;
       if (code !== 200) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -8,7 +8,7 @@ const { Schema } = require('metaschema');
 const request = (url, { method, body }) =>
   new Promise((resolve, reject) => {
     const proto = url.startsWith('https') ? https : http;
-    const headers = { 'Content-Type': 'application/json' };
+    const headers = { 'Content-Type': 'application/json', 'Content-Length': body ? Buffer.byteLength(body) : 0 };
     const req = proto.request(url, { method, headers }, (res) => {
       const code = res.statusCode;
       if (code !== 200) {


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
