### PR TITLE
Fix cached resources loaders

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -60,6 +60,7 @@ class Application extends events.EventEmitter {
 
     this.schemas = new Schemas('schemas', this);
     this.static = new Resources('static', this);
+    this.cert = new Resources('cert', this);
     this.resources = new Resources('resources', this);
     this.api = new Interfaces('api', this);
     this.lib = new Modules('lib', this);
@@ -70,7 +71,6 @@ class Application extends events.EventEmitter {
     this.starts = [];
     this.Application = Application;
     this.Error = Error;
-    this.cert = null;
     this.config = null;
     this.logger = null;
     this.console = null;
@@ -98,6 +98,7 @@ class Application extends events.EventEmitter {
     await this.parallel([
       this.schemas.load(),
       this.static.load(),
+      this.cert.load(),
       this.resources.load(),
       (async () => {
         await this.lib.load();

--- a/lib/application.js
+++ b/lib/application.js
@@ -60,7 +60,7 @@ class Application extends events.EventEmitter {
 
     this.schemas = new Schemas('schemas', this);
     this.static = new Resources('static', this);
-    this.cert = new Resources('cert', this);
+    this.cert = new Resources('cert', this, { ext: '.pem' });
     this.resources = new Resources('resources', this);
     this.api = new Interfaces('api', this);
     this.lib = new Modules('lib', this);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -16,7 +16,7 @@ class Cache {
       const files = await fsp.readdir(targetPath, { withFileTypes: true });
       for (const file of files) {
         const { name } = file;
-        if (name.startsWith('.') && !name.endsWith('.js')) continue;
+        if (name.startsWith('.eslint')) continue;
         const filePath = path.join(targetPath, name);
         if (file.isDirectory()) await this.load(filePath);
         else await this.change(filePath);

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -8,9 +8,10 @@ const { Cache } = require('./cache.js');
 const WIN = process.platform === 'win32';
 
 class Resources extends Cache {
-  constructor(place, application) {
+  constructor(place, application, options = {}) {
     super(place, application);
     this.files = new Map();
+    this.ext = options.ext;
   }
 
   get(key) {
@@ -29,6 +30,7 @@ class Resources extends Cache {
   }
 
   async change(filePath) {
+    if (this.ext && !filePath.endsWith(filePath)) return;
     try {
       const data = await fsp.readFile(filePath);
       const key = this.getKey(filePath);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('node:path');
-const fsp = require('node:fs').promises;
 const { parentPort, threadId, workerData } = require('node:worker_threads');
 const { Config } = require('metaconfiguration');
 const { Logger } = require('metalog');
@@ -47,26 +46,6 @@ process.on('unhandledRejection', logError('unhandledRejection'));
     process.exit(0);
   }
 
-  if (config.server.protocol === 'https') {
-    const certPath = path.join(application.path, 'cert');
-    try {
-      const key = await fsp.readFile(path.join(certPath, 'key.pem'));
-      const cert = await fsp.readFile(path.join(certPath, 'cert.pem'));
-      application.cert = { key, cert };
-    } catch {
-      if (threadId === 1) console.error('Can not load TLS certificates');
-      process.exit(0);
-    }
-  }
-
-  await application.init();
-
-  const { kind, port } = workerData;
-  if (kind === 'server' || kind === 'balancer') {
-    const options = { ...config.server, port, kind };
-    application.server = new Server(application, options);
-  }
-
   const stop = async () => {
     if (application.finalization) return;
     console.info(`Graceful shutdown in worker ${threadId}`);
@@ -95,6 +74,24 @@ process.on('unhandledRejection', logError('unhandledRejection'));
   };
 
   const handlers = { stop, invoke };
+
+  await application.init();
+
+  const { kind, port } = workerData;
+  if (kind === 'server' || kind === 'balancer') {
+    const options = { ...config.server, port, kind };
+    if (config.server.protocol === 'https') {
+      options.key = application.cert.files.get('/key.pem');
+      options.cert = application.cert.files.get('/cert.pem');
+      if (!options.key || !options.cert) {
+        if (threadId === 1) {
+          console.error('Can not load TLS certificates');
+          await stop();
+        }
+      }
+    }
+    application.server = new Server(application, options);
+  }
 
   parentPort.on('message', async (msg) => {
     const handler = handlers[msg.name];

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -81,14 +81,13 @@ process.on('unhandledRejection', logError('unhandledRejection'));
   if (kind === 'server' || kind === 'balancer') {
     const options = { ...config.server, port, kind };
     if (config.server.protocol === 'https') {
-      options.key = application.cert.files.get('/key.pem');
-      options.cert = application.cert.files.get('/cert.pem');
-      if (!options.key || !options.cert) {
-        if (threadId === 1) {
-          console.error('Can not load TLS certificates');
-          await stop();
-        }
+      const key = application.cert.files.get('/key.pem');
+      const cert = application.cert.files.get('/cert.pem');
+      if (threadId === 1 && (!key || !cert)) {
+        console.error('Can not load TLS certificates');
+        await stop();
       }
+      Object.assign(options, { key, cert });
     }
     application.server = new Server(application, options);
   }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
