### PR TITLE
Load and use certificates with TLS and SNI

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -12,6 +12,7 @@ const metawatch = require('metawatch');
 const { Interfaces } = require('./interfaces.js');
 const { Modules } = require('./modules.js');
 const { Resources } = require('./resources.js');
+const { Certificates } = require('./certificates.js');
 const { Schemas } = require('./schemas.js');
 const scheduler = require('./scheduler.js');
 const auth = require('./auth.js');
@@ -60,7 +61,7 @@ class Application extends events.EventEmitter {
 
     this.schemas = new Schemas('schemas', this);
     this.static = new Resources('static', this);
-    this.cert = new Resources('cert', this, { ext: '.pem' });
+    this.cert = new Certificates('cert', this, { ext: '.pem' });
     this.resources = new Resources('resources', this);
     this.api = new Interfaces('api', this);
     this.lib = new Modules('lib', this);
@@ -208,6 +209,14 @@ class Application extends events.EventEmitter {
       const place = relPath.substring(0, sepIndex);
       this[place].delete(filePath);
       if (threadId === 1) this.console.debug('Deleted: /' + relPath);
+    });
+
+    this.watcher.on('after', (changes) => {
+      const certPath = path.join(this.path, 'cert');
+      const changed = changes.some(([name]) => name.startsWith(certPath));
+      if (!changed) return;
+      this.cert.after(changes);
+      if (threadId === 1) this.console.debug('New certificates for: *');
     });
   }
 

--- a/lib/certificates.js
+++ b/lib/certificates.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const tls = require('node:tls');
+const { Resources } = require('./resources.js');
+
+class Certificates extends Resources {
+  constructor(place, application, options = {}) {
+    super(place, application, options);
+    this.domains = new Map();
+  }
+
+  get(key) {
+    return this.domains.get(key);
+  }
+
+  after(changes) {
+    if (!changes) return;
+    const key = this.files.get('/key.pem');
+    const cert = this.files.get('/cert.pem');
+    const creds = tls.createSecureContext({ key, cert });
+    this.domains.set('*', { key, cert, creds });
+    if (!this.application.server?.httpServer.setSecureContext) return;
+    this.application.server.httpServer.setSecureContext({ key, cert });
+  }
+}
+
+module.exports = { Certificates };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -81,13 +81,19 @@ process.on('unhandledRejection', logError('unhandledRejection'));
   if (kind === 'server' || kind === 'balancer') {
     const options = { ...config.server, port, kind };
     if (config.server.protocol === 'https') {
-      const key = application.cert.files.get('/key.pem');
-      const cert = application.cert.files.get('/cert.pem');
-      if (threadId === 1 && (!key || !cert)) {
-        console.error('Can not load TLS certificates');
+      application.cert.after([]);
+      const domain = application.cert.get('*');
+      if (!domain) {
+        if (threadId === 1) console.error('Can not load TLS certificates');
         await stop();
+        return;
       }
+      const { key, cert, creds } = domain;
       Object.assign(options, { key, cert });
+      options.SNICallback = (servername, callback) => {
+        if (!creds) callback(new Error(`No certificate for ${servername}`));
+        callback(null, creds);
+      };
     }
     application.server = new Server(application, options);
   }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
