### PR TITLE
Catch TLS errors loading certificates

### DIFF
--- a/lib/certificates.js
+++ b/lib/certificates.js
@@ -24,6 +24,7 @@ class Certificates extends Resources {
       this.application.server.httpServer.setSecureContext({ key, cert });
       this.domains.set('*', { key, cert, creds });
     } catch (error) {
+      this.domains.delete('*');
       this.application.console.error(error.stack);
     }
   }

--- a/lib/certificates.js
+++ b/lib/certificates.js
@@ -17,10 +17,15 @@ class Certificates extends Resources {
     if (!changes) return;
     const key = this.files.get('/key.pem');
     const cert = this.files.get('/cert.pem');
-    const creds = tls.createSecureContext({ key, cert });
-    this.domains.set('*', { key, cert, creds });
-    if (!this.application.server?.httpServer.setSecureContext) return;
-    this.application.server.httpServer.setSecureContext({ key, cert });
+    try {
+      const creds = tls.createSecureContext({ key, cert });
+      this.domains.set('*', { key, cert, creds });
+      if (!this.application.server?.httpServer.setSecureContext) return;
+      this.application.server.httpServer.setSecureContext({ key, cert });
+      this.domains.set('*', { key, cert, creds });
+    } catch (error) {
+      this.application.console.error(error.stack);
+    }
   }
 }
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
