### PR TITLE
Support multiple SSL certificates

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -215,7 +215,9 @@ class Application extends events.EventEmitter {
       const certPath = path.join(this.path, 'cert');
       const changed = changes.some(([name]) => name.startsWith(certPath));
       if (!changed) return;
-      this.cert.after(changes);
+      setTimeout(() => {
+        this.cert.after(changes);
+      }, timeout);
       if (threadId === 1) this.console.debug('New certificates for: *');
     });
   }

--- a/lib/application.js
+++ b/lib/application.js
@@ -61,7 +61,7 @@ class Application extends events.EventEmitter {
 
     this.schemas = new Schemas('schemas', this);
     this.static = new Resources('static', this);
-    this.cert = new Certificates('cert', this, { ext: '.pem' });
+    this.cert = new Certificates('cert', this, { ext: ['pem', 'domains'] });
     this.resources = new Resources('resources', this);
     this.api = new Interfaces('api', this);
     this.lib = new Modules('lib', this);

--- a/lib/application.js
+++ b/lib/application.js
@@ -99,8 +99,8 @@ class Application extends events.EventEmitter {
     await this.parallel([
       this.schemas.load(),
       this.static.load(),
-      this.cert.load(),
       this.resources.load(),
+      this.cert.load(),
       (async () => {
         await this.lib.load();
         await this.db.load();
@@ -211,14 +211,11 @@ class Application extends events.EventEmitter {
       if (threadId === 1) this.console.debug('Deleted: /' + relPath);
     });
 
-    this.watcher.on('after', (changes) => {
+    this.watcher.on('before', async (changes) => {
       const certPath = path.join(this.path, 'cert');
-      const changed = changes.some(([name]) => name.startsWith(certPath));
-      if (!changed) return;
-      setTimeout(() => {
-        this.cert.after(changes);
-      }, timeout);
-      if (threadId === 1) this.console.debug('New certificates for: *');
+      const changed = changes.filter(([name]) => name.startsWith(certPath));
+      if (changed.length === 0) return;
+      await this.cert.before(changes);
     });
   }
 

--- a/lib/certificates.js
+++ b/lib/certificates.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const tls = require('node:tls');
+const path = require('node:path');
+const { threadId } = require('node:worker_threads');
 const { Resources } = require('./resources.js');
 
 class Certificates extends Resources {
@@ -13,19 +15,56 @@ class Certificates extends Resources {
     return this.domains.get(key);
   }
 
-  after(changes) {
-    if (!changes) return;
-    const key = this.files.get('/key.pem');
-    const cert = this.files.get('/cert.pem');
-    try {
-      const creds = tls.createSecureContext({ key, cert });
-      this.domains.set('*', { key, cert, creds });
-      if (!this.application.server?.httpServer.setSecureContext) return;
-      this.application.server.httpServer.setSecureContext({ key, cert });
-      this.domains.set('*', { key, cert, creds });
-    } catch (error) {
-      this.domains.delete('*');
-      this.application.console.error(error.stack);
+  async before(changes) {
+    const folders = new Set();
+    for (const [name, event] of changes) {
+      const dir = path.dirname(name);
+      const folder = path.basename(dir);
+      folders.add(folder);
+      if (event === 'change') await super.change(name);
+      if (event === 'datele') super.delete(name);
+    }
+    await this.init([...folders]);
+    changes.length = 0;
+  }
+
+  folders() {
+    const folders = new Set();
+    const files = [...this.files.keys()];
+    for (const name of files) {
+      const dir = path.dirname(name);
+      const folder = path.basename(dir);
+      folders.add(folder);
+    }
+    return [...folders];
+  }
+
+  async load(targetPath) {
+    await super.load(targetPath);
+    await this.init();
+  }
+
+  async init(folders = this.folders()) {
+    for (const domain of folders) {
+      const key = this.files.get(`/${domain}/key.pem`);
+      const cert = this.files.get(`/${domain}/cert.pem`);
+      const domains = this.files.get(`/${domain}/.domains`).toString();
+      if (!key || !cert || !domains) continue;
+      const names = domains.split(/[\r\n\s]+/).filter((s) => s.length !== 0);
+      if (threadId === 1) {
+        const list = names.join(', ');
+        this.application.console.log(`New certificate for: ${list}`);
+      }
+      try {
+        const creds = tls.createSecureContext({ key, cert });
+        const context = { key, cert, creds };
+        for (const name of names) this.domains.set(name, context);
+        if (!this.application.server?.httpServer.setSecureContext) continue;
+        this.application.server.httpServer.setSecureContext({ key, cert });
+      } catch (error) {
+        for (const name of names) this.domains.delete(name);
+        this.application.console.error(error.stack);
+      }
     }
   }
 }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -30,7 +30,8 @@ class Resources extends Cache {
   }
 
   async change(filePath) {
-    if (this.ext && !filePath.endsWith(filePath)) return;
+    const ext = metautil.fileExt(filePath);
+    if (this.ext && !this.ext.includes(ext)) return;
     try {
       const data = await fsp.readFile(filePath);
       const key = this.getKey(filePath);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -87,7 +87,7 @@ process.on('unhandledRejection', logError('unhandledRejection'));
         await stop();
         return;
       }
-      const { key, cert, creds } = domain;
+      const { key, cert } = domain;
       Object.assign(options, { key, cert });
       options.SNICallback = (servername, callback) => {
         const domain = application.cert.get(servername);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -81,8 +81,7 @@ process.on('unhandledRejection', logError('unhandledRejection'));
   if (kind === 'server' || kind === 'balancer') {
     const options = { ...config.server, port, kind };
     if (config.server.protocol === 'https') {
-      application.cert.after([]);
-      const domain = application.cert.get('*');
+      const domain = application.cert.get('localhost');
       if (!domain) {
         if (threadId === 1) console.error('Can not load TLS certificates');
         await stop();
@@ -91,8 +90,9 @@ process.on('unhandledRejection', logError('unhandledRejection'));
       const { key, cert, creds } = domain;
       Object.assign(options, { key, cert });
       options.SNICallback = (servername, callback) => {
-        if (!creds) callback(new Error(`No certificate for ${servername}`));
-        callback(null, creds);
+        const domain = application.cert.get(servername);
+        if (!domain) callback(new Error(`No certificate for ${servername}`));
+        callback(null, domain.creds);
       };
     }
     application.server = new Server(application, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "metaconfiguration": "^2.1.10",
         "metalog": "^3.1.9",
         "metaschema": "^2.1.3",
-        "metautil": "^3.7.1",
+        "metautil": "^3.7.2",
         "metavm": "^1.2.4",
         "metawatch": "^1.0.7"
       },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "metaconfiguration": "^2.1.10",
     "metalog": "^3.1.9",
     "metaschema": "^2.1.3",
-    "metautil": "^3.7.1",
+    "metautil": "^3.7.2",
     "metavm": "^1.2.4",
     "metawatch": "^1.0.7"
   },


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
