### PR TITLE
Support large files

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -237,13 +237,22 @@ class Application extends events.EventEmitter {
     const filePath = urlPath + (folder ? 'index.html' : '');
     const fileExt = metautil.fileExt(filePath);
     const data = this.static.get(filePath);
-    if (data) {
+    if (Buffer.isBuffer(data)) {
       transport.write(data, 200, fileExt);
       return;
     }
     if (!folder && this.static.get(urlPath + '/index.html')) {
       const query = params ? '?' + params : '';
       transport.redirect(urlPath + '/' + query);
+      return;
+    }
+    const absPath = path.join(this.static.path, url);
+    if (absPath.startsWith(this.static.path)) {
+      const readable = fs.createReadStream(absPath);
+      readable.on('error', () => {
+        transport.error(404);
+      });
+      transport.write(readable, 200, fileExt);
       return;
     }
     transport.error(404);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -22,7 +22,8 @@ class Cache {
         else await this.change(filePath);
       }
     } catch (error) {
-      this.application.console.error(error.stack);
+      const console = this.application.console || global.console;
+      console.error(error.stack);
     }
   }
 }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -6,12 +6,14 @@ const metautil = require('metautil');
 const { Cache } = require('./cache.js');
 
 const WIN = process.platform === 'win32';
+const MAX_FILE_SIZE = '10 mb';
 
 class Resources extends Cache {
   constructor(place, application, options = {}) {
     super(place, application);
     this.files = new Map();
     this.ext = options.ext;
+    this.maxFileSize = -1;
   }
 
   get(key) {
@@ -30,16 +32,23 @@ class Resources extends Cache {
   }
 
   async change(filePath) {
+    if (this.maxFileSize === -1) {
+      const maxFileSize = this.application.config?.cache?.maxFileSize;
+      this.maxFileSize = metautil.sizeToBytes(maxFileSize || MAX_FILE_SIZE);
+    }
     const ext = metautil.fileExt(filePath);
     if (this.ext && !this.ext.includes(ext)) return;
     try {
-      const data = await fsp.readFile(filePath);
+      const { size } = await fsp.stat(filePath);
       const key = this.getKey(filePath);
-      this.files.set(key, data);
-    } catch (error) {
-      if (error.code !== 'ENOENT') {
-        this.application.console.error(error.stack);
+      if (size > this.maxFileSize) {
+        this.files.set(key, { size });
+      } else {
+        const data = await fsp.readFile(filePath);
+        this.files.set(key, data);
       }
+    } catch {
+      this.delete(filePath);
     }
   }
 }

--- a/schemas/config/.types.js
+++ b/schemas/config/.types.js
@@ -1,0 +1,8 @@
+({
+  size: {
+    js: 'string',
+    kind: 'scalar',
+    rules: ['length'],
+    symbols: '1234567890kmgtpezyb. ',
+  },
+});

--- a/schemas/config/cache.js
+++ b/schemas/config/cache.js
@@ -1,0 +1,5 @@
+({
+  size: 'size',
+  maxFileSize: 'size',
+  avoid: { array: 'string', required: false },
+});


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
