### PR TITLE
Fix SNI callback

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -84,7 +84,7 @@ process.on('unhandledRejection', logError('unhandledRejection'));
       options.SNICallback = (servername, callback) => {
         const domain = application.cert.get(servername);
         if (!domain) callback(new Error(`No certificate for ${servername}`));
-        callback(null, domain.creds);
+        else callback(null, domain.creds);
       };
     }
     application.server = new Server(application, options);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
