### PR TITLE
Graceful shutdown start message

### DIFF
--- a/impress.js
+++ b/impress.js
@@ -181,6 +181,7 @@ const stopApplication = (dir) => {
 
 const stop = async () => {
   const portsClosed = new Promise((resolve) => {
+    impress.console.info('Graceful shutdown in worker 0');
     const timeout = setTimeout(() => {
       impress.console.error('Exit with graceful shutdown timeout');
       resolve();


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
