### PR TITLE
Require modules from application, not from impress

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const CWD = process.cwd();
+
 const wt = require('node:worker_threads');
+const { createRequire } = require('node:module');
 const metautil = require('metautil');
+const appRequire = createRequire(`file://${CWD}/server.js`);
 
 const node = {};
 const npm = {};
@@ -20,7 +24,7 @@ const core = ['metaconfiguration', 'metalog', 'metavm', 'metawatch'];
 const metapkg = [...core, 'metautil', 'metacom', 'metaschema', ...optional];
 
 const npmpkg = ['ws'];
-const pkg = require(process.cwd() + '/package.json');
+const pkg = require(CWD + '/package.json');
 if (pkg.dependencies) npmpkg.push(...Object.keys(pkg.dependencies));
 const dependencies = [...internals, ...npmpkg, ...metapkg];
 
@@ -44,7 +48,7 @@ for (const name of dependencies) {
   if (name === 'impress') continue;
   let lib = null;
   try {
-    lib = internals.includes(name) ? require(`node:${name}`) : require(name);
+    lib = internals.includes(name) ? require(`node:${name}`) : appRequire(name);
   } catch {
     if (npmpkg.includes(name) || !optional.includes(name)) {
       notLoaded.add(name);


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1707

<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
