### PR TITLE
Support new globals including `fetch`

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -34,7 +34,10 @@ const UserApplication = class Application extends node.events.EventEmitter {
 };
 
 const { COMMON_CONTEXT } = metarhia.metavm;
-const SANDBOX = { ...COMMON_CONTEXT, Error, DomainError, node, npm, metarhia };
+const ERRORS = { Error, DomainError };
+const NAMESPACES = { node, npm, metarhia, process };
+const POLY = { fetch: metarhia.metautil.fetch };
+const SANDBOX = { ...COMMON_CONTEXT, ...ERRORS, ...NAMESPACES, ...POLY };
 
 const ERR_INIT = 'Can not initialize an Application';
 
@@ -125,7 +128,7 @@ class Application extends node.events.EventEmitter {
     const server = { host, port, protocol };
     const userAppData = { worker, server, resources, schemas, scheduler };
     const application = new UserApplication(this, userAppData);
-    const sandbox = { ...SANDBOX, console, application, config, process };
+    const sandbox = { ...SANDBOX, console, application, config };
     sandbox.api = {};
     sandbox.lib = this.lib.tree;
     sandbox.db = this.db.tree;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "metalog": "^3.1.12",
         "metaschema": "^2.1.5",
         "metautil": "^3.11.0",
-        "metavm": "^1.2.4",
+        "metavm": "^1.2.6",
         "metawatch": "^1.1.1"
       },
       "devDependencies": {
@@ -2077,9 +2077,9 @@
       }
     },
     "node_modules/metavm": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/metavm/-/metavm-1.2.5.tgz",
-      "integrity": "sha512-ED6aPHRvumUaUQH11eVKR+rjTNLvAdV1vCjGSeNHS+dnhOXt8e5Nvh1i3sN3xqc4MZ/mVmk+eOUd5DAba1cTtQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/metavm/-/metavm-1.2.6.tgz",
+      "integrity": "sha512-mn0dn7/NLbkVoGgYFkYxI6QriBrkbpzL/ZQ4x/RxNnksorkIqD/KeMr1ClYTy2cpoyGpymTpqtuZP2vKweOSEw==",
       "engines": {
         "node": "16 || 18 || 19 || 20"
       },
@@ -4829,9 +4829,9 @@
       "integrity": "sha512-gvOgGV2oXZ3DcbDbstSH4wKha3YCk2w206+tD/JXRZNFfoC65tTMAmxzQMyZ9wlC7+Sd0Fn/IAzwaf7+pI2kZQ=="
     },
     "metavm": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/metavm/-/metavm-1.2.5.tgz",
-      "integrity": "sha512-ED6aPHRvumUaUQH11eVKR+rjTNLvAdV1vCjGSeNHS+dnhOXt8e5Nvh1i3sN3xqc4MZ/mVmk+eOUd5DAba1cTtQ=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/metavm/-/metavm-1.2.6.tgz",
+      "integrity": "sha512-mn0dn7/NLbkVoGgYFkYxI6QriBrkbpzL/ZQ4x/RxNnksorkIqD/KeMr1ClYTy2cpoyGpymTpqtuZP2vKweOSEw=="
     },
     "metawatch": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "metalog": "^3.1.12",
     "metaschema": "^2.1.5",
     "metautil": "^3.11.0",
-    "metavm": "^1.2.4",
+    "metavm": "^1.2.6",
     "metawatch": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Support node.js globals: fetch, AbortController, Event, EventTarget, MessageChannel, MessageEvent, MessagePort

Refs: https://github.com/metarhia/metavm/issues/108

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
