### PR TITLE
Fix MessagePort leak

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -17,6 +17,7 @@ const invoke = async ({ method, args, exclusive = false }) => {
   const msg = { name: 'invoke', exclusive, data, port };
   return new Promise((resolve, reject) => {
     port2.on('message', ({ error, data }) => {
+      port2.close();
       if (error) reject(error);
       else resolve(data);
     });

--- a/lib/planner.js
+++ b/lib/planner.js
@@ -188,6 +188,7 @@ class Planner {
     const msg = { name: 'invoke', data, port };
     return new Promise((resolve, reject) => {
       port2.on('message', ({ error, data }) => {
+        port2.close();
         if (error) reject(error);
         else resolve(data);
       });

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -6,6 +6,7 @@ const add = async (task) => {
   const { port1, port2 } = new wt.MessageChannel();
   return new Promise((resolve) => {
     port2.on('message', ({ id }) => {
+      port2.close();
       resolve(id);
     });
     const msg = { name: 'task', action: 'add', port: port1, task };


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

 Generally, it would be better to open only one MessagePort pair between main and worker threads. But this will fix a leak for now/ 

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

Here is the summery of the memory snapshots of a dev server after a few hours of running a scheduled task every 10s.

Without the fix:
<img width="397" alt="Screenshot 2023-08-02 at 16 46 24" src="https://github.com/metarhia/impress/assets/17278974/c0d9d34c-a891-427e-bde6-bc22a893fea2">

With the fix:
<img width="402" alt="Screenshot 2023-08-02 at 16 46 36" src="https://github.com/metarhia/impress/assets/17278974/552642a9-26d2-4a05-8b26-f1172f358023">


