### PR TITLE
Move semaphore from metacom to `Application`

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -2,7 +2,7 @@
 
 const { node, npm, metarhia, wt } = require('./deps.js');
 const { MessageChannel, parentPort, threadId, workerData } = wt;
-const { Error, DomainError } = metarhia.metautil;
+const { Error, DomainError, Semaphore } = metarhia.metautil;
 const { Api } = require('./api.js');
 const { Code } = require('./code.js');
 const { Static } = require('./static.js');
@@ -69,6 +69,7 @@ class Application extends node.events.EventEmitter {
     this.console = null;
     this.auth = null;
     this.watcher = null;
+    this.semaphore = null;
     this.mode = process.env.MODE || 'prod';
   }
 
@@ -115,6 +116,8 @@ class Application extends node.events.EventEmitter {
     this.initialization = false;
     this.sandbox.application.emit('initialized');
     if (this.mode === 'test' && threadId === 1) this.test();
+    const { concurrency, size, timeout } = this.config.server.queue;
+    this.semaphore = new Semaphore(concurrency, size, timeout);
   }
 
   async test() {

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -40,19 +40,19 @@ class Procedure {
   }
 
   async enter() {
-    await this.application.server.semaphore.enter();
+    await this.application.semaphore.enter();
     if (this.concurrency) {
       try {
         await this.semaphore.enter();
       } catch (error) {
-        this.application.server.semaphore.leave();
+        this.application.semaphore.leave();
         throw error;
       }
     }
   }
 
   leave() {
-    this.application.server.semaphore.leave();
+    this.application.semaphore.leave();
     if (this.concurrency) this.semaphore.leave();
   }
 


### PR DESCRIPTION
Refs: https://github.com/metarhia/metacom/issues/449

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
