### PR TITLE
Fix `application.invoke` availability on `start` hook

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -19,8 +19,7 @@ const UserApplication = class Application extends EventEmitter {};
 const { COMMON_CONTEXT } = metarhia.metavm;
 const ERRORS = { Error, DomainError };
 const NAMESPACES = { node, npm, metarhia, process };
-const POLY = { fetch: metarhia.metautil.fetch };
-const SANDBOX = { ...COMMON_CONTEXT, ...ERRORS, ...NAMESPACES, ...POLY };
+const SANDBOX = { ...COMMON_CONTEXT, ...ERRORS, ...NAMESPACES };
 
 const ERR_INIT = 'Can not initialize an Application';
 const ERR_TEST = 'Application tests failed';
@@ -71,9 +70,10 @@ class Application extends EventEmitter {
     }
   }
 
-  async load() {
+  async load({ invoke }) {
     this.startWatch();
     this.createSandbox();
+    this.sandbox.application.invoke = invoke;
     this.sandbox.application.emit('loading');
     await this.parallel([
       this.schemas.load(),
@@ -91,6 +91,7 @@ class Application extends EventEmitter {
     this.starts = [];
     await this.api.load();
     this.sandbox.application.emit('loaded');
+    await this.start();
   }
 
   async start() {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -96,9 +96,7 @@ parentPort.on('message', async (msg) => {
     process.exit(0);
   }
 
-  await application.load();
-  application.sandbox.application.invoke = invoke;
-  await application.start();
+  await application.load({ invoke });
   console.info(`Application started in worker ${threadId}`);
   parentPort.postMessage({ name: 'started', kind: workerData.kind });
 })().catch(logError(`Can not start worker ${threadId}`));


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
