### PR TITLE
Improve loading of submodules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
         node:
           - 18
           - 20
+          - 21
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased][unreleased]
 
+## [3.0.13][] - 2023-10-22
+
+- Fix serve static not in cache (e.g. certbot challenge)
+- Fix `application.invoke` availability on `start` hook
+- Support node.js 21.x
+
 ## [3.0.12][] - 2023-10-22
 
 - Update metacom and metautil with important error.code and timeout fixes
@@ -352,7 +358,8 @@ First generation of application server with following features
 - Connection drivers for database engines: MongoDB, PgSQL, Oracle, MySQL
 - Support GeoIP, health monitoring, task scheduling, server-side templating
 
-[unreleased]: https://github.com/metarhia/impress/compare/v3.0.12...HEAD
+[unreleased]: https://github.com/metarhia/impress/compare/v3.0.13...HEAD
+[3.0.13]: https://github.com/metarhia/impress/compare/v3.0.12...v3.0.13
 [3.0.12]: https://github.com/metarhia/impress/compare/v3.0.11...v3.0.12
 [3.0.11]: https://github.com/metarhia/impress/compare/v3.0.10...v3.0.11
 [3.0.10]: https://github.com/metarhia/impress/compare/v3.0.9...v3.0.10

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -54,8 +54,16 @@ const loadModule = (name) => {
   const subKeys = Object.keys(pkg.exports).map((key) => key.substring(2));
   const subNames = subKeys.filter(validSubmodules);
   for (const subName of subNames) {
-    const sub = appRequire(name + '/' + subName);
-    lib[subName] = sub;
+    try {
+      const sub = appRequire(name + '/' + subName);
+      lib[subName] = sub;
+    } catch (e) {
+      if (e.message.startsWith("Cannot find module '")) {
+        const moduleName = e.message.substring(20, e.message.indexOf("'\n"));
+        const optional = pkg.peerDependenciesMeta?.[moduleName].optional;
+        if (optional) continue; else throw e;
+      }
+    }
   }
   return lib;
 };

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -56,12 +56,14 @@ const loadModule = (name) => {
   for (const subName of subNames) {
     try {
       const sub = appRequire(name + '/' + subName);
+      if (lib[subName] && lib[subName] === sub[subName]) continue;
       lib[subName] = sub;
     } catch (e) {
       if (e.message.startsWith("Cannot find module '")) {
         const moduleName = e.message.substring(20, e.message.indexOf("'\n"));
         const optional = pkg.peerDependenciesMeta?.[moduleName].optional;
-        if (optional) continue; else throw e;
+        if (optional) continue;
+        else throw e;
       }
     }
   }

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -61,7 +61,7 @@ const loadModule = (name) => {
     } catch (e) {
       if (e.message.startsWith("Cannot find module '")) {
         const moduleName = e.message.substring(20, e.message.indexOf("'\n"));
-        const optional = pkg.peerDependenciesMeta?.[moduleName].optional;
+        const optional = pkg.peerDependenciesMeta?.[moduleName]?.optional;
         if (optional) continue;
         else throw e;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": "18 || 20 || 21"
+        "node": "^18.15 || 20 || 21"
       },
       "funding": {
         "type": "patreon",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "impress",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "impress",
-      "version": "3.0.12",
+      "version": "3.0.13",
       "license": "MIT",
       "dependencies": {
         "metacom": "^3.1.2",
@@ -30,7 +30,7 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 21"
       },
       "funding": {
         "type": "patreon",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "metalog": "^3.1.13",
         "metaschema": "^2.1.5",
         "metautil": "^3.15.0",
-        "metavm": "^1.3.0",
+        "metavm": "^1.4.0",
         "metawatch": "^1.1.1"
       },
       "devDependencies": {
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -206,12 +206,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
-      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
+      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/ws": {
@@ -970,26 +970,26 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
-      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
+      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-node": "^0.3.9",
         "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.13.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
         "semver": "^6.3.1",
         "tsconfig-paths": "^3.14.2"
       },
@@ -1469,15 +1469,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -2153,11 +2144,11 @@
       }
     },
     "node_modules/metavm": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/metavm/-/metavm-1.3.0.tgz",
-      "integrity": "sha512-UPC6KaP6R0YscV/nxNRMcUKrm0ZAlRjb9qNyB2oFaFzA43KXA0a3b3aZYhqaeOuGF0vIIp8dL2dJc0Sd4tojKw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/metavm/-/metavm-1.4.0.tgz",
+      "integrity": "sha512-mLO1cskBf3sYDEU7S3WblK55HRuJtXZG081fNgIhrlYXhvcIKZEdohBX21jZbfcTHClwE7lC/dWQOBwofHTVfg==",
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 21"
       },
       "funding": {
         "type": "patreon",
@@ -3275,9 +3266,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "node_modules/unicode-length": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "metalog": "^3.1.13",
     "metaschema": "^2.1.5",
     "metautil": "^3.15.0",
-    "metavm": "^1.3.0",
+    "metavm": "^1.4.0",
     "metawatch": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "fmt": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/*.ts\""
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 21"
   },
   "dependencies": {
     "metacom": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impress",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "Enterprise application server for Node.js",
   "license": "MIT",
@@ -38,7 +38,7 @@
   "readmeFilename": "README.md",
   "repository": {
     "type": "git",
-    "url": "https://github.com/metarhia/impress"
+    "url": "git+https://github.com/metarhia/impress.git"
   },
   "bugs": {
     "url": "https://github.com/metarhia/impress/issues",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,11 @@
   },
   "main": "impress.js",
   "types": "types/impress.d.ts",
-  "files": ["lib/", "schemas/", "types/"],
+  "files": [
+    "lib/",
+    "schemas/",
+    "types/"
+  ],
   "scripts": {
     "test": "npm run lint && npm run types && metatests test/",
     "types": "tsc -p types/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "fmt": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/*.ts\""
   },
   "engines": {
-    "node": "18 || 20 || 21"
+    "node": "^18.15 || 20 || 21"
   },
   "dependencies": {
     "metacom": "^3.1.2",


### PR DESCRIPTION
### 1. Don't load submodules with not installed optional dependencies

Some packages may have optional dependencies.
If there was an error during loading a submodue, and it's a missing optional dependency error, just skip this submodule.

Closes https://github.com/metarhia/impress/issues/1937

### 2. Skip submodules if they have already been loaded as a part of main module

Example: `some-module`

`package.json`

```js
{
  "exports": {
    ".": {
      // ...
      "default": "./index.js"
    },
    "./submodule": {
      // ...
      "default": "./submodule.js"
    }
  }
}
```

`index.js`

```js
export * from './submodule';
```

`submodule.js`

```js
export const submodule = () => {};
```

The main module exports all from the submodule.
And the submodule exports a function with the same name as a submodule name.
So when loading the submodule, `lib` already have a property `submodule`.

Closes https://github.com/metarhia/impress/issues/1938

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
