### PR TITLE
Improve loading of submodules

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -54,8 +54,16 @@ const loadModule = (name) => {
   const subKeys = Object.keys(pkg.exports).map((key) => key.substring(2));
   const subNames = subKeys.filter(validSubmodules);
   for (const subName of subNames) {
-    const sub = appRequire(name + '/' + subName);
-    lib[subName] = sub;
+    try {
+      const sub = appRequire(name + '/' + subName);
+      lib[subName] = sub;
+    } catch (e) {
+      if (e.message.startsWith("Cannot find module '")) {
+        const moduleName = e.message.substring(20, e.message.indexOf("'\n"));
+        const optional = pkg.peerDependenciesMeta?.[moduleName].optional;
+        if (optional) continue; else throw e;
+      }
+    }
   }
   return lib;
 };

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -56,12 +56,14 @@ const loadModule = (name) => {
   for (const subName of subNames) {
     try {
       const sub = appRequire(name + '/' + subName);
+      if (lib[subName] && lib[subName] === sub[subName]) continue;
       lib[subName] = sub;
     } catch (e) {
       if (e.message.startsWith("Cannot find module '")) {
         const moduleName = e.message.substring(20, e.message.indexOf("'\n"));
         const optional = pkg.peerDependenciesMeta?.[moduleName].optional;
-        if (optional) continue; else throw e;
+        if (optional) continue;
+        else throw e;
       }
     }
   }

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -61,7 +61,7 @@ const loadModule = (name) => {
     } catch (e) {
       if (e.message.startsWith("Cannot find module '")) {
         const moduleName = e.message.substring(20, e.message.indexOf("'\n"));
-        const optional = pkg.peerDependenciesMeta?.[moduleName].optional;
+        const optional = pkg.peerDependenciesMeta?.[moduleName]?.optional;
         if (optional) continue;
         else throw e;
       }


### PR DESCRIPTION
### 1. Don't load submodules with not installed optional dependencies

Some packages may have optional dependencies.
If there was an error during loading a submodue, and it's a missing optional dependency error, just skip this submodule.

Closes https://github.com/metarhia/impress/issues/1937

### 2. Skip submodules if they have already been loaded as a part of main module

Example: `some-module`

`package.json`

```js
{
  "exports": {
    ".": {
      // ...
      "default": "./index.js"
    },
    "./submodule": {
      // ...
      "default": "./submodule.js"
    }
  }
}
```

`index.js`

```js
export * from './submodule';
```

`submodule.js`

```js
export const submodule = () => {};
```

The main module exports all from the submodule.
And the submodule exports a function with the same name as a submodule name.
So when loading the submodule, `lib` already have a property `submodule`.

Closes https://github.com/metarhia/impress/issues/1938

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
