### PR TITLE
Fix Procedure level queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Fixed API endpoints local queue settings applying
+
 ## [3.0.13][] - 2023-10-22
 
 - Fix serve static not in cache (e.g. certbot challenge)

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -41,7 +41,7 @@ class Procedure {
 
   async enter() {
     await this.application.semaphore.enter();
-    if (this.concurrency) {
+    if (this.semaphore) {
       try {
         await this.semaphore.enter();
       } catch (error) {
@@ -53,7 +53,7 @@ class Procedure {
 
   leave() {
     this.application.semaphore.leave();
-    if (this.concurrency) this.semaphore.leave();
+    if (this.semaphore) this.semaphore.leave();
   }
 
   async invoke(context, args = {}) {

--- a/test/procedure.js
+++ b/test/procedure.js
@@ -10,11 +10,10 @@ metatests.testAsync('lib/procedure', async (test) => {
   });
 
   const application = {
-    server: {
-      semaphore: {
-        async enter() {},
-        leave() {},
-      },
+    Error,
+    semaphore: {
+      async enter() {},
+      leave() {},
     },
   };
 
@@ -62,11 +61,9 @@ metatests.testAsync('lib/procedure validate', async (test) => {
 
   const application = {
     Error,
-    server: {
-      semaphore: {
-        async enter() {},
-        leave() {},
-      },
+    semaphore: {
+      async enter() {},
+      leave() {},
     },
   };
   const procedure = new Procedure(script, 'method', application);
@@ -93,11 +90,9 @@ metatests.testAsync('lib/procedure validate async', async (test) => {
 
   const application = {
     Error,
-    server: {
-      semaphore: {
-        async enter() {},
-        leave() {},
-      },
+    semaphore: {
+      async enter() {},
+      leave() {},
     },
   };
   const procedure = new Procedure(script, 'method', application);
@@ -124,11 +119,9 @@ metatests.testAsync('lib/procedure timeout', async (test) => {
 
   const application = {
     Error,
-    server: {
-      semaphore: {
-        async enter() {},
-        leave() {},
-      },
+    semaphore: {
+      async enter() {},
+      leave() {},
     },
   };
 


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1945

API endpoint local queue params not working at all. I had investigate that the problem in Procedure class and originated from commit  "Improve Procedure class PR-URL: https://github.com/metarhia/impress/pull/1569 " https://github.com/metarhia/impress/pull/1569/commits/434e6c111fd2dd9da04b6e2e5605cafd07098b1d Where was applied changes into constructor:
- `Object.assign(this, exp);` removed
- expected property `concurrency` of the API endpoint was replaced with `queue` object containing `queue.concurrency`
- BUT `this.concurrency` not assigned directly anymore (as for example done for `this.parameters`.

However methods `enter` and `leave` still checking`this.concurrency` for existance as of today. 
https://github.com/metarhia/impress/blob/4cabe81e1cef6870a10d7c7b020f8618db3bdbf3/lib/procedure.js#L42-L57

As a result local Semaphore of the Procedure never applied. There should be check for the property `this.semaphore` instead. It suitable for this purpose because it will be `null` in case API endpoint doesn't provide queue settings.   

Before applying the fix I also added test case `lib/procedure queue` in [/test/procedure.js](https://github.com/metarhia/impress/blob/master/test/procedure.js) . By the way I had fixed application stub in Procedure tests to make it comply with updated contract (was changed by https://github.com/metarhia/impress/pull/1898).


- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
