### PR TITLE
WIP: Reimplement global timeouts.request usage

### DIFF
--- a/test/procedure.js
+++ b/test/procedure.js
@@ -10,11 +10,10 @@ metatests.testAsync('lib/procedure', async (test) => {
   });
 
   const application = {
-    server: {
-      semaphore: {
-        async enter() {},
-        leave() {},
-      },
+    Error,
+    semaphore: {
+      async enter() {},
+      leave() {},
     },
   };
 
@@ -62,11 +61,9 @@ metatests.testAsync('lib/procedure validate', async (test) => {
 
   const application = {
     Error,
-    server: {
-      semaphore: {
-        async enter() {},
-        leave() {},
-      },
+    semaphore: {
+      async enter() {},
+      leave() {},
     },
   };
   const procedure = new Procedure(script, 'method', application);
@@ -93,11 +90,9 @@ metatests.testAsync('lib/procedure validate async', async (test) => {
 
   const application = {
     Error,
-    server: {
-      semaphore: {
-        async enter() {},
-        leave() {},
-      },
+    semaphore: {
+      async enter() {},
+      leave() {},
     },
   };
   const procedure = new Procedure(script, 'method', application);
@@ -124,11 +119,9 @@ metatests.testAsync('lib/procedure timeout', async (test) => {
 
   const application = {
     Error,
-    server: {
-      semaphore: {
-        async enter() {},
-        leave() {},
-      },
+    semaphore: {
+      async enter() {},
+      leave() {},
     },
   };
 


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1947

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
