### PR TITLE
Reimplement global timeouts.request setting usage during Procedure invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Fixed API endpoints local queue settings applying
+- Reimplement global timeouts.request usage during a Procedure invocation
 
 ## [3.0.13][] - 2023-10-22
 

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -31,7 +31,8 @@ class Procedure {
     this.description = exp.description || '';
     this.access = exp.access || '';
     this.validate = exp.validate || null;
-    this.timeout = exp.timeout || 0;
+    const { timeouts } = application.config.server;
+    this.timeout = (exp.timeout ?? timeouts.request) || 0;
     this.serializer = exp.serialize || null;
     this.protocols = exp.protocols || null;
     this.deprecated = exp.deprecated || false;

--- a/test/api.js
+++ b/test/api.js
@@ -14,6 +14,7 @@ const application = {
   absolute(relative) {
     return path.join(this.path, relative);
   },
+  config: { server: { timeouts: {} } },
 };
 
 metatests.testAsync('lib/api load', async (test) => {


### PR DESCRIPTION
This PR contains latest rebased version of commit from  https://github.com/metarhia/impress/pull/1948 that was closed in intermediary state.

Updated and added test cases to control the behavior:
- if application env has no timeouts.request in the config Procedure fallback to 0 timeout
- config.server.timeouts.request applied to procedure script execution
- local timeout setting of the script overrides global timeouts.request  in both directions.

Closes: https://github.com/metarhia/impress/issues/1947 
Note: the issue already closed by mistake
Refs: https://github.com/metarhia/impress/pull/1948

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

### Situation investigation

The use of config.server.timeouts.request setting originated from commit  "Read timeouts from config" https://github.com/metarhia/metacom/pull/166 . That time it was used in metacom `lib/server.js` as a general timeout of any request processing. 

Setting was used in metacom `Server` until commit "Remove duplicated rpc call timeout" https://github.com/metarhia/metacom/commit/6062718a452e8f76ddcb7fb2e8775cbb79a8e728 where request level timer was completely removed from metacom `Server` in favor of newly implemented local timeout of a "Procedure execution" https://github.com/metarhia/impress/pull/1490 .

However `Procedure` since that time till now had used only local script level `timeout` setting, so the config.server.timeouts.request value wasn't applied to anything.

Based on that previously made decisions I decided that global timeouts.request setting must be used as default value for `Procedure` execution in case of absent local `timeout` setting. On the other side, existing local `timeout` value of a script, in my opinion should override the global: making timeout shorter or even longer than global.
