### PR TITLE
Worker task execution timeout (global)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Fixed API endpoints local queue settings applying
+- Worker task execution global timeout implementation
 
 ## [3.0.13][] - 2023-10-22
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -50,15 +50,26 @@ const handlers = {
 
   invoke: async ({ exclusive, data, port }) => {
     const { method, args } = data;
-    const { sandbox } = application;
+    const { sandbox, config } = application;
     const handler = metarhia.metautil.namespaceByPath(sandbox, method);
     if (!handler) {
       const error = new Error('Handler not found');
       return void port.postMessage({ name: 'error', error });
     }
     const msg = { name: 'invoke', status: 'done' };
+    const { timeout } = config.server.workers;
     try {
-      const result = await handler(args);
+      let result;
+      if (timeout) {
+        const ac = new AbortController();
+        result = await Promise.race([
+          metarhia.metautil.timeout(timeout, ac.signal),
+          handler(args),
+        ]);
+        ac.abort();
+      } else {
+        result = await handler(args);
+      }
       port.postMessage({ ...msg, data: result });
     } catch (error) {
       port.postMessage({ name: 'error', error });


### PR DESCRIPTION
The setting server.workers.timeout in application configuration is required but allows zero value to switch off the limit.

Closes: https://github.com/metarhia/impress/issues/1950

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
