### PR TITLE
Use module.builtinModules to get native node namespaces

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -3,7 +3,7 @@
 const CWD = process.cwd();
 
 const wt = require('node:worker_threads');
-const { createRequire } = require('node:module');
+const { createRequire, builtinModules } = require('node:module');
 const metautil = require('metautil');
 const appRequire = createRequire(`file://${CWD}/server.js`);
 
@@ -11,14 +11,7 @@ const node = {};
 const npm = {};
 const metarhia = {};
 
-const sys = ['util', 'buffer', 'child_process', 'os', 'v8', 'vm'];
-const tools = ['path', 'string_decoder', 'querystring'];
-const test = ['assert', 'test'];
-const streams = ['stream', 'fs', 'crypto', 'zlib', 'readline'];
-const async = ['perf_hooks', 'async_hooks', 'timers', 'events'];
-const net = ['dns', 'net', 'tls', 'http', 'https', 'http2', 'dgram'];
-const internals = [...sys, ...tools, ...streams, ...async, ...net, ...test];
-
+const internals = [...builtinModules];
 const optional = ['metasql', 'test'];
 const core = ['metaconfiguration', 'metalog', 'metavm', 'metawatch'];
 const metapkg = [...core, 'metautil', 'metacom', 'metaschema', ...optional];


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
