### PR TITLE
Fixed: TypeError: domain.enter is not a function

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -12,8 +12,9 @@ const npm = {};
 const metarhia = {};
 
 const deprecated = ['sys', 'domain', 'cluster', 'punycode', 'trace_events'];
-const notDeprecated = (s) => !s.startsWith('_') && !deprecated.includes(s);
-const internals = [...builtinModules].filter(notDeprecated);
+const unsupported = [...deprecated, 'repl', 'node:sea'];
+const isSupported = (s) => !s.startsWith('_') && !unsupported.includes(s);
+const internals = [...builtinModules].filter(isSupported);
 
 const optional = ['metasql', 'test'];
 const core = ['metaconfiguration', 'metalog', 'metavm', 'metawatch'];


### PR DESCRIPTION
- Removed node:repl form autoloaded dependencies
- Removed node:sea form autoloaded dependencies

<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [ ] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [ ] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
