### PR TITLE
Support compression for static files

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -124,9 +124,8 @@ class Static extends Place {
     let file = this.find(filePath);
     if (file.data && file.stat) {
       if (file.code === -1) return void transport.write(file.data, 200, 'html');
-      return void transport.write(file.data, file.code, fileExt, {
-        contentEncoding: this.compressType,
-      });
+      const opt = { contentEncoding: this.compressType };
+      return void transport.write(file.data, file.code, fileExt, opt);
     }
     const absPath = join(this.path, url);
     if (absPath.startsWith(this.path)) {

--- a/lib/static.js
+++ b/lib/static.js
@@ -181,7 +181,9 @@ class Static extends Place {
     const fileExt = metautil.fileExt(filePath);
     let file = this.find(filePath);
     if (file.data && file.stat) {
-      if (file.code === -1) return void this.write(req, res, file.data, 200, 'html');
+      if (file.code === -1) {
+        return void this.write(req, res, file.data, 200, 'html');
+      }
       const opt = { contentEncoding: this.compressType };
       return void this.write(req, res, file.data, file.code, fileExt, opt);
     }

--- a/lib/static.js
+++ b/lib/static.js
@@ -21,12 +21,26 @@ const status = (code) => {
   return file;
 };
 
+const COMPRESSORS = {
+  gzip: node.zlib.createGzip,
+  deflate: node.zlib.createDeflate,
+  br: node.zlib.createBrotliCompress,
+  zstd: node.zlib.createZstdCompress,
+};
+
 class Static extends Place {
   constructor(name, application, options = {}) {
     super(name, application);
     this.files = new Map();
     this.ext = options.ext;
     this.maxFileSize = -1;
+    const { compressType } = options;
+    const compressor = COMPRESSORS[compressType]?.();
+    if (compressType && !compressor) {
+      throw new Error(`Unsupported compression type ${compressType}`);
+    }
+    this.compressType = compressType;
+    this.compressor = compressor;
   }
 
   get(key) {
@@ -44,6 +58,12 @@ class Static extends Place {
     this.files.delete(key);
   }
 
+  compress(filePath) {
+    const fileStream = node.fs.createReadStream(filePath);
+    fileStream.pipe(this.compressor);
+    return node.streamConsumers.buffer(this.compressor);
+  }
+
   async change(filePath) {
     if (this.maxFileSize === -1) {
       const maxFileSize = this.application.config?.cache?.maxFileSize;
@@ -58,7 +78,13 @@ class Static extends Place {
       if (stat.size > this.maxFileSize) {
         this.files.set(key, { data: null, stat });
       } else {
-        const data = await node.fsp.readFile(filePath);
+        let data = null;
+        if (this.compressor) {
+          data = await this.compress(filePath);
+          stat.size = data.length;
+        } else {
+          data = await node.fsp.readFile(filePath);
+        }
         this.files.set(key, { data, stat });
       }
     } catch {
@@ -98,7 +124,9 @@ class Static extends Place {
     let file = this.find(filePath);
     if (file.data && file.stat) {
       if (file.code === -1) return void transport.write(file.data, 200, 'html');
-      return void transport.write(file.data, file.code, fileExt);
+      return void transport.write(file.data, file.code, fileExt, {
+        contentEncoding: this.compressType,
+      });
     }
     const absPath = join(this.path, url);
     if (absPath.startsWith(this.path)) {
@@ -106,7 +134,7 @@ class Static extends Place {
       if (!stat) stat = await node.fsp.stat(absPath).catch(() => null);
       if (stat && stat.isFile()) {
         const { size } = stat;
-        const options = { size };
+        const options = { size, contentEncoding: this.compressType };
         let code = 200;
         const { headers } = transport.req;
         if (headers.range) {

--- a/lib/static.js
+++ b/lib/static.js
@@ -86,18 +86,23 @@ const COMPRESSORS = {
 };
 
 class Static extends Place {
+  files = new Map();
+  compressor = null;
+  compressType = 'none';
+  maxFileSize = -1;
+
   constructor(name, application, options = {}) {
     super(name, application);
-    this.files = new Map();
-    this.ext = options.ext;
-    this.maxFileSize = -1;
-    const { compressType } = options;
-    const compressor = COMPRESSORS[compressType]?.();
-    if (compressType && !compressor) {
-      throw new Error(`Unsupported compression type ${compressType}`);
+    const { compressType, ext } = options;
+    this.ext = ext;
+    if (compressType) {
+      const compressor = COMPRESSORS[compressType];
+      if (!compressor) {
+        throw new Error(`Unsupported compression type ${compressType}`);
+      }
+      this.compressType = compressType;
+      this.compressor = compressor();
     }
-    this.compressType = compressType;
-    this.compressor = compressor;
   }
 
   get(key) {

--- a/test/static.js
+++ b/test/static.js
@@ -32,3 +32,89 @@ test('lib/static load - should load static files correctly', async () => {
   assert.strictEqual(cache.ext, undefined);
   assert.strictEqual(cache.maxFileSize, 10000000);
 });
+
+test('lib/static load - should compress correctly by gzip', async () => {
+  const cache = new Static('lib', application, { compressType: 'gzip' });
+  assert.strictEqual(cache.files instanceof Map, true);
+  assert.strictEqual(cache.files.size, 0);
+  assert.strictEqual(cache.ext, undefined);
+  assert.strictEqual(cache.maxFileSize, -1);
+  assert.strictEqual(cache.get('/example/add.js'), undefined);
+
+  await cache.load();
+  assert.strictEqual(cache.files.size, 13);
+  const file = cache.get('/example/add.js');
+  assert.strictEqual(file.data instanceof Buffer, true);
+  assert.strictEqual(file.data.length, 116);
+  assert.strictEqual(cache.get('/example/unknown.js'), undefined);
+  assert.strictEqual(cache.ext, undefined);
+  assert.strictEqual(cache.maxFileSize, 10000000);
+});
+
+test('lib/static load - should compress correctly by deflate', async () => {
+  const cache = new Static('lib', application, {
+    compressType: 'deflate',
+  });
+  assert.strictEqual(cache.files instanceof Map, true);
+  assert.strictEqual(cache.files.size, 0);
+  assert.strictEqual(cache.ext, undefined);
+  assert.strictEqual(cache.maxFileSize, -1);
+  assert.strictEqual(cache.get('/example/add.js'), undefined);
+
+  await cache.load();
+  assert.strictEqual(cache.files.size, 13);
+  const file = cache.get('/example/add.js');
+  assert.strictEqual(file.data instanceof Buffer, true);
+  assert.strictEqual(file.data.length, 104);
+  assert.strictEqual(cache.get('/example/unknown.js'), undefined);
+  assert.strictEqual(cache.ext, undefined);
+  assert.strictEqual(cache.maxFileSize, 10000000);
+});
+
+test('lib/static load - should compress correctly by brotli', async () => {
+  const cache = new Static('lib', application, {
+    compressType: 'br',
+  });
+  assert.strictEqual(cache.files instanceof Map, true);
+  assert.strictEqual(cache.files.size, 0);
+  assert.strictEqual(cache.ext, undefined);
+  assert.strictEqual(cache.maxFileSize, -1);
+  assert.strictEqual(cache.get('/example/add.js'), undefined);
+
+  await cache.load();
+  assert.strictEqual(cache.files.size, 13);
+  const file = cache.get('/example/add.js');
+  assert.strictEqual(file.data instanceof Buffer, true);
+  assert.strictEqual(file.data.length, 100);
+  assert.strictEqual(cache.get('/example/unknown.js'), undefined);
+  assert.strictEqual(cache.ext, undefined);
+  assert.strictEqual(cache.maxFileSize, 10000000);
+});
+
+test('lib/static load - should compress correctly by zstd', async () => {
+  const cache = new Static('lib', application, {
+    compressType: 'zstd',
+  });
+  assert.strictEqual(cache.files instanceof Map, true);
+  assert.strictEqual(cache.files.size, 0);
+  assert.strictEqual(cache.ext, undefined);
+  assert.strictEqual(cache.maxFileSize, -1);
+  assert.strictEqual(cache.get('/example/add.js'), undefined);
+
+  await cache.load();
+  assert.strictEqual(cache.files.size, 13);
+  const file = cache.get('/example/add.js');
+  assert.strictEqual(file.data instanceof Buffer, true);
+  assert.strictEqual(file.data.length, 109);
+  assert.strictEqual(cache.get('/example/unknown.js'), undefined);
+  assert.strictEqual(cache.ext, undefined);
+  assert.strictEqual(cache.maxFileSize, 10000000);
+});
+
+test('lib/static - should throw error on unsupported compression', async () => {
+  assert.throws(() => {
+    new Static('lib', application, {
+      compressType: 'unsupported',
+    });
+  }, new Error('Unsupported compression type unsupported'));
+});

--- a/test/static.js
+++ b/test/static.js
@@ -2,6 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert');
+const zlib = require('node:zlib');
 const path = require('node:path');
 const { Static } = require('../lib/static.js');
 
@@ -91,25 +92,27 @@ test('lib/static load - should compress correctly by brotli', async () => {
   assert.strictEqual(cache.maxFileSize, 10000000);
 });
 
-test('lib/static load - should compress correctly by zstd', async () => {
-  const cache = new Static('lib', application, {
-    compressType: 'zstd',
-  });
-  assert.strictEqual(cache.files instanceof Map, true);
-  assert.strictEqual(cache.files.size, 0);
-  assert.strictEqual(cache.ext, undefined);
-  assert.strictEqual(cache.maxFileSize, -1);
-  assert.strictEqual(cache.get('/example/add.js'), undefined);
+if (zlib.zstdCompress) {
+  test('lib/static load - should compress correctly by zstd', async () => {
+    const cache = new Static('lib', application, {
+      compressType: 'zstd',
+    });
+    assert.strictEqual(cache.files instanceof Map, true);
+    assert.strictEqual(cache.files.size, 0);
+    assert.strictEqual(cache.ext, undefined);
+    assert.strictEqual(cache.maxFileSize, -1);
+    assert.strictEqual(cache.get('/example/add.js'), undefined);
 
-  await cache.load();
-  assert.strictEqual(cache.files.size, 13);
-  const file = cache.get('/example/add.js');
-  assert.strictEqual(file.data instanceof Buffer, true);
-  assert.strictEqual(file.data.length, 109);
-  assert.strictEqual(cache.get('/example/unknown.js'), undefined);
-  assert.strictEqual(cache.ext, undefined);
-  assert.strictEqual(cache.maxFileSize, 10000000);
-});
+    await cache.load();
+    assert.strictEqual(cache.files.size, 13);
+    const file = cache.get('/example/add.js');
+    assert.strictEqual(file.data instanceof Buffer, true);
+    assert.strictEqual(file.data.length, 109);
+    assert.strictEqual(cache.get('/example/unknown.js'), undefined);
+    assert.strictEqual(cache.ext, undefined);
+    assert.strictEqual(cache.maxFileSize, 10000000);
+  });
+}
 
 test('lib/static - should throw error on unsupported compression', async () => {
   assert.throws(() => {

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -20,6 +20,7 @@ export interface InvokeTarget {
 
 export interface Static {
   get(name: string): unknown;
+  compress(filePath: string): Promise<Buffer>;
 }
 
 export interface Schemas {

--- a/types/impress.d.ts
+++ b/types/impress.d.ts
@@ -14,6 +14,7 @@ import * as _qs from 'node:querystring';
 import * as _querystring from 'node:querystring';
 import * as _assert from 'node:assert';
 import * as _stream from 'node:stream';
+import * as _streamConsumers from 'node:stream/consumers';
 import * as _fs from 'node:fs';
 import * as _crypto from 'node:crypto';
 import * as _zlib from 'node:zlib';
@@ -77,6 +78,8 @@ declare global {
     const querystring: typeof _qs;
     const assert: typeof _assert;
     const stream: typeof _stream;
+    const stream_consumers: typeof _streamConsumers;
+    const streamConsumers: typeof _streamConsumers;
     const fs: typeof _fs;
     const fsp: typeof _fs.promises;
     const crypto: typeof _crypto;


### PR DESCRIPTION
Added support for compression for static files (gzip, deflate, br, zstd)
To use compression, we need to pass the compression type into the options:
`new Static('lib', application, {
    compressType: 'br',
  });`
  issue: #2002

In [metacom](https://github.com/metarhia/metacom/pull/527) it's enough to refactor transport (http)

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
