### PR TITLE
Webhook are not related to metacom

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -179,14 +179,6 @@ class Application extends EventEmitter {
     return proc;
   }
 
-  getHook(name) {
-    const unit = this.api.collection[name];
-    if (!unit) return null;
-    const hook = unit[unit.default];
-    if (!hook) return null;
-    return hook.router;
-  }
-
   execute(method, ...args) {
     return method(...args).catch((error) => {
       const msg = `Failed to execute method: ${error?.message}`;


### PR DESCRIPTION
Web hooks are not related to metacom and should not be implemented here, you can do it separately on the top of http(s)

- [X] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [X] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [X] update .d.ts typings
