### PR TITLE
Security: Arbitrary sandbox method execution via unvalidated invoke path

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -19,7 +19,7 @@ const UserApplication = class Application extends EventEmitter {};
 
 const { COMMON_CONTEXT } = metarhia.metavm;
 const ERRORS = { Error, DomainError };
-const NAMESPACES = { node, npm, metarhia, process };
+const NAMESPACES = { npm, metarhia };
 const SANDBOX = { ...COMMON_CONTEXT, ...ERRORS, ...NAMESPACES };
 
 const ERR_INIT = 'Can not initialize an Application';

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -25,6 +25,7 @@ process.on('unhandledRejection', logError('unhandledRejection'));
 
 let callId = 0;
 const calls = new Map();
+const INVOKE_PREFIX = 'api.';
 
 const invoke = async ({ method, args, exclusive = false }) => {
   const id = ++callId;
@@ -65,8 +66,13 @@ const handlers = {
     const msg = { name: 'invoke', to: from };
     const { timeout } = config.server.workers;
     const { id, method = '', args = {} } = data;
+    if (!method.startsWith(INVOKE_PREFIX)) {
+      const error = { message: 'Handler not allowed' };
+      const data = { id, status: 'error', error };
+      return void parentPort.postMessage({ ...msg, data });
+    }
     const handler = metarhia.metautil.namespaceByPath(sandbox, method);
-    if (!handler) {
+    if (typeof handler !== 'function') {
       const error = { message: 'Handler not found' };
       const data = { id, status: 'error', error };
       return void parentPort.postMessage({ ...msg, data });


### PR DESCRIPTION
## Problem

Worker message handling resolves and executes `data.method` directly using `namespaceByPath(sandbox, method)` without any allowlist or namespace restriction. If an attacker can influence scheduled task `run` values or invoke messages, they can call dangerous globals exposed in sandbox (for example `process.*` or `node.child_process.*`), resulting in remote code execution or denial of service.

**Severity**: `critical`
**File**: `lib/worker.js`

## Solution

Restrict callable targets to a strict allowlist (for example only `api.*` procedures), reject method paths outside approved prefixes, and enforce authorization checks before dispatch. Do not expose powerful globals (`process`, full `node` namespace) to callable contexts.

## Changes

- `lib/worker.js` (modified)
- `lib/application.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
