### PR TITLE
Security: Sandbox exposes high-privilege globals to dynamically loaded code

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -19,7 +19,7 @@ const UserApplication = class Application extends EventEmitter {};
 
 const { COMMON_CONTEXT } = metarhia.metavm;
 const ERRORS = { Error, DomainError };
-const NAMESPACES = { node, npm, metarhia, process };
+const NAMESPACES = {};
 const SANDBOX = { ...COMMON_CONTEXT, ...ERRORS, ...NAMESPACES };
 
 const ERR_INIT = 'Can not initialize an Application';

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -25,6 +25,7 @@ process.on('unhandledRejection', logError('unhandledRejection'));
 
 let callId = 0;
 const calls = new Map();
+const FORBIDDEN_NAMESPACES = new Set(['process', 'node', 'npm', 'metarhia']);
 
 const invoke = async ({ method, args, exclusive = false }) => {
   const id = ++callId;
@@ -65,6 +66,12 @@ const handlers = {
     const msg = { name: 'invoke', to: from };
     const { timeout } = config.server.workers;
     const { id, method = '', args = {} } = data;
+    const root = method.split('.')[0];
+    if (FORBIDDEN_NAMESPACES.has(root)) {
+      const error = { message: 'Handler not found' };
+      const data = { id, status: 'error', error };
+      return void parentPort.postMessage({ ...msg, data });
+    }
     const handler = metarhia.metautil.namespaceByPath(sandbox, method);
     if (!handler) {
       const error = { message: 'Handler not found' };


### PR DESCRIPTION
## Problem

The sandbox context includes `process`, `node`, `npm`, and `metarhia` namespaces. API/procedure scripts are loaded from filesystem and executed in this context. Any compromised or untrusted script can access OS/process primitives, read environment secrets, spawn processes, or perform network/file operations.

**Severity**: `high`
**File**: `lib/application.js`

## Solution

Harden the sandbox by exposing only minimal safe capabilities required for business logic. Remove `process` and sensitive Node modules by default, and provide explicit capability injection per procedure/plugin.

## Changes

- `lib/application.js` (modified)
- `lib/worker.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
